### PR TITLE
Update GitHub Pages generation script for API changes

### DIFF
--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -38,9 +38,10 @@ export DOCC_JSON_PRETTYPRINT="YES"
 # Generate documentation for the 'SwiftDocCPlugin' target and output it
 # to the /docs subdirectory in the gh-pages worktree directory.
 export SWIFTPM_ENABLE_COMMAND_PLUGINS=1 
-swift package --target SwiftDocCPlugin  \
+swift package \
     --allow-writing-to-directory "$SWIFT_DOCC_PLUGIN_ROOT/gh-pages/docs" \
     generate-documentation \
+    --target SwiftDocCPlugin \
     --disable-indexing \
     --transform-for-static-hosting \
     --hosting-base-path swift-docc-plugin \


### PR DESCRIPTION
## Summary

Per #1, The target argument is now passed directly to the plugin instead of to SwiftPM itself.

## Testing

Run `/bin/update-gh-pages-documentation-site` and confirm it works as expected.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
