### PR TITLE
Fix compatibility with Xcode 13.3 Beta 3

### DIFF
--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -11,7 +11,7 @@ import PackagePlugin
 
 /// Creates a Swift-DocC documentation archive from a Swift Package.
 @main struct SwiftDocCConvert: CommandPlugin {
-    func performCommand(context: PluginContext, arguments: [String]) throws {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
         // We'll be creating commands that invoke `docc`, so start by locating it.
         let doccExecutableURL = try context.doccExecutable
         

--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -11,7 +11,7 @@ import PackagePlugin
 
 /// Creates and previews a Swift-DocC documentation archive from a Swift Package.
 @main struct SwiftDocCPreview: CommandPlugin {
-    func performCommand(context: PluginContext, arguments: [String]) throws {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
         // We'll be creating commands that invoke `docc`, so start by locating it.
         let doccExecutableURL = try context.doccExecutable
         


### PR DESCRIPTION
## Summary

The PackagePlugin module in Xcode 13.3 Beta 3 requires the `async` version of the `CommandPlugin.performCommand` method.

This marks the `performCommand` method in both SwiftDocCConvert and SwiftDocCPreview as `async` to meet this requirement.

## Testing

Build the version of the plugin in this PR with Xcode 13.3 Beta 3 and confirm that the build passes.
## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ Non-functional change.
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
