### PR TITLE
Re-enable preview server test cases

### DIFF
--- a/IntegrationTests/Tests/Utility/XCTestCase+availablePort.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+availablePort.swift
@@ -17,9 +17,6 @@ extension XCTestCase {
     /// This allows tests to more reliably run in parallel and in CI where
     /// we can't be sure which ports will be available.
     func getAvailablePort() throws -> Int {
-        // https://bugs.swift.org/browse/SR-15912
-        try XCTSkipIf(true, "SR-15912: Trunk snapshot compiler for linux miscompiles NIO.")
-        
         // Start up the server.
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let server = ServerBootstrap(group: eventLoopGroup)


### PR DESCRIPTION
## Summary

A new trunk compiler has been built since SR-15912 was resolved so we can re-enable the preview server test cases that rely on SwiftNIO.