### PR TITLE
Add plugin instructions to documentation

### DIFF
--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/SwiftDocCPlugin.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/SwiftDocCPlugin.md
@@ -7,8 +7,19 @@ Produce Swift-DocC documentation for Swift Package libraries and executables.
 The Swift-DocC plugin is a Swift Package Manager command plugin that supports building
 documentation for SwiftPM libraries and executables.
 
-After adding the plugin as a dependency in your Swift package manifest, you can build
-documentation for the libraries and executables in that package and its dependencies by running the
+First, add the plugin as a dependency in your Swift package manifest:
+
+```swift
+let package = Package(
+    products: […],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ],
+    targets: […]
+)
+```
+
+Then, build documentation for the libraries and executables in that package and its dependencies by running the
 following from the command-line:
 
     $ swift package generate-documentation


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

Add instructions to set up the plugin in the documentation. When reading the documentation at https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/, it might not be totally clear that the plugin needs to be added to your package first, especially if the developer is not yet familiar with the concept of SwiftPM plugins.

## Dependencies

None.

## Testing

No functional changes.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
