### PR TITLE
Update Documentation For Private Github Pages

### DIFF
--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -90,7 +90,7 @@ Here's a mapping of the tokens in the above command to what they should be repla
 |----------------------------|----------------------------------------------------------------------------------------------------------------|
 | `[path-to-docs-directory]` | The path to the `/docs` directory at the root of the repository you configured for publishing to GitHub pages. |
 | `[target-name]`            | The name of the Swift Package target you'd like to build documentation for.                                    |
-| `[hosting-base-path]`      | The base path your website will be hosted at. Most likely this will be the name of your GitHub repository.     |
+| `[hosting-base-path]`      | The base path, if any, your website will be hosted at. Most likely this will be the name of your GitHub repository.     |
 
 ## Publishing the Documentation Site
 

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -46,11 +46,22 @@ Before running the `swift package generate-documentation` command, you'll need t
     Your documentation site will be published at something like
 
     ```txt
-    https://<username>.github.io/<repository-name>
+    https://<username>.github.io/<repository-name>/...
     ```
 
     and Swift-DocC needs to know about any base path after the `github.io` portion in order
     to correctly configure relative links. In the above case, that would be `<repository-name>`.
+    
+    However, if you publish the page as a private github page, then the url structure will be different.
+    
+    Your documentation site will be published at something like
+    
+    ```txt
+    https://<unique-subdomain>.pages.github.io/...
+    ```
+    
+    As you can see, this is quite different from the public pages url. Each repo in your organization, will have its own subdomain, for hosting its private pages. Hence, the `[hosting-base-path]` argument is not needed for private pages, as it has its own subdomain.
+    
 
 2. Which **target** in your Swift Package would you like to publish documentation for?
 
@@ -79,7 +90,7 @@ Here's a mapping of the tokens in the above command to what they should be repla
 |----------------------------|----------------------------------------------------------------------------------------------------------------|
 | `[path-to-docs-directory]` | The path to the `/docs` directory at the root of the repository you configured for publishing to GitHub pages. |
 | `[target-name]`            | The name of the Swift Package target you'd like to build documentation for.                                    |
-| `[hosting-base-path]`      | The base path your website will be hosted at. Most likely this will be the name of your GitHub repository. If private pages are being used, please refrain from using this option.
+| `[hosting-base-path]`      | The base path your website will be hosted at. Most likely this will be the name of your GitHub repository.     |
 
 ## Publishing the Documentation Site
 
@@ -95,7 +106,7 @@ Once the push completes, the documentation site will be available at:
 
     https://<username>.github.io/<repository-name>/documentation/<target-name>
     
-If the documenation is published as a private page, then each repository in the organization has a unique subdomain. So the documentation site will be available at:
+If the documenation is published as a private page, then the documentation site will be available at:
 
     https://<unique-subdomain>.pages.github.io/documentation/<target-name>
 

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -79,8 +79,7 @@ Here's a mapping of the tokens in the above command to what they should be repla
 |----------------------------|----------------------------------------------------------------------------------------------------------------|
 | `[path-to-docs-directory]` | The path to the `/docs` directory at the root of the repository you configured for publishing to GitHub pages. |
 | `[target-name]`            | The name of the Swift Package target you'd like to build documentation for.                                    |
-| `[hosting-base-path]`      | The base path your website will be hosted at. Most likely this will be the name of your GitHub repository.     |
-
+| `[hosting-base-path]`      | The base path your website will be hosted at. Most likely this will be the name of your GitHub repository. If private pages are being used, please refrain from using this option.
 
 ## Publishing the Documentation Site
 
@@ -95,5 +94,9 @@ branch you configured for publishing to GitHub Pages.
 Once the push completes, the documentation site will be available at:
 
     https://<username>.github.io/<repository-name>/documentation/<target-name>
+    
+If the documenation is published as a private page, then each repository in the organization has a unique subdomain. So the documentation site will be available at:
+
+    https://<unique-subdomain>.pages.github.io/documentation/<target-name>
 
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -60,7 +60,9 @@ Before running the `swift package generate-documentation` command, you'll need t
     https://<unique-subdomain>.pages.github.io/...
     ```
     
-    As you can see, this is quite different from the public pages url. Each repo in your organization, will have its own subdomain, for hosting its private pages. Hence, the `[hosting-base-path]` argument is not needed for private pages, as it has its own subdomain.
+    Because these websites have their own unique subdomain, your website is published directly at the root and the `[hosting-base-path]` argument is not needed. 
+    
+    > Tip: If your unsure what kind of GitHub Pages site you have, pay close attention to the URL listed on the GitHub Pages tab of your repository's settings after you've enabled the feature.
     
 
 2. Which **target** in your Swift Package would you like to publish documentation for?

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -108,7 +108,7 @@ Once the push completes, the documentation site will be available at:
 
     https://<username>.github.io/<repository-name>/documentation/<target-name>
     
-If the documenation is published as a private page, then the documentation site will be available at:
+If your GitHub Pages site is published privately, then the documentation will be available at:
 
     https://<unique-subdomain>.pages.github.io/documentation/<target-name>
 

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Publishing to GitHub Pages.md
@@ -52,7 +52,7 @@ Before running the `swift package generate-documentation` command, you'll need t
     and Swift-DocC needs to know about any base path after the `github.io` portion in order
     to correctly configure relative links. In the above case, that would be `<repository-name>`.
     
-    However, if you publish the page as a private github page, then the url structure will be different.
+    However, there are some configurations of GitHub Pages where this base URL path will not be required. For example, GitHub Enterprise Cloud has a feature that allows you to publish your GitHub Pages site privately. In situations like this, the URL structure will be different and will not require a custom base path.
     
     Your documentation site will be published at something like
     


### PR DESCRIPTION
Bug/issue #, if applicable: 
https://forums.swift.org/t/docc-for-private-github-repos/55770/2

## Summary

Added documentation for github private pages .
For private repos, hosting-base-path is not needed, as each repo is served from its own subdomain. Also the url format for such pages is also different.

## Dependencies

Not Applicable

## Testing

Not Applicable

## Checklist

- [ ] Added tests
- [ ] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
