### PR TITLE
Set a custom display name for the plugin's documentation

### DIFF
--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/SwiftDocCPlugin.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/SwiftDocCPlugin.md
@@ -2,6 +2,10 @@
 
 Produce Swift-DocC documentation for Swift Package libraries and executables.
 
+@Metadata {
+    @DisplayName("Swift-DocC Plugin")
+}
+
 ## Overview
 
 The Swift-DocC plugin is a Swift Package Manager command plugin that supports building


### PR DESCRIPTION
## Summary

With Swift 5.7, Swift-DocC has support for setting a custom display name in documentation. We can use it here to render the top-level page of the plugin's documentation as "Swift-DocC Plugin" instead of "SwiftDocCPlugin".

<img width="1343" alt="Screen Shot 2022-06-17 at 2 19 03 PM" src="https://user-images.githubusercontent.com/6750147/174402507-9e19cc6d-02dd-4dd1-8b20-ae85857ee006.png">


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ NFC
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
