### PR TITLE
Snippets: Change show/hide markers to snippet.show and snippet.hide

### DIFF
--- a/IntegrationTests/Tests/Fixtures/PackageWithSnippets/_Snippets/TestTest.swift
+++ b/IntegrationTests/Tests/Fixtures/PackageWithSnippets/_Snippets/TestTest.swift
@@ -12,6 +12,6 @@ import Library
 let best = BestStruct()
 best.best()
 
-// MARK: Hide
+// snippet.hide
 
 print(best)

--- a/Sources/Snippets/Parsing/PlainTextSnippetExtractor.swift
+++ b/Sources/Snippets/Parsing/PlainTextSnippetExtractor.swift
@@ -13,7 +13,7 @@ enum SnippetVisibility {
 
 extension StringProtocol {
     /// If the string is a line comment, attempt to parse
-    /// a ``SnippetVisibility`` with `mark: show` or `mark: hide`.
+    /// a ``SnippetVisibility`` with `snippet.show` or `snippet.hide`.
     var parsedVisibilityMark: SnippetVisibility? {
         guard var comment = parsedLineCommentText else {
             return nil
@@ -21,9 +21,9 @@ extension StringProtocol {
 
         comment = comment.drop { $0.isWhitespace }
 
-        if comment.lowercased().starts(with: "mark: show") {
+        if comment.lowercased().starts(with: "snippet.show") {
             return SnippetVisibility.shown
-        } else if comment.lowercased().starts(with: "mark: hide") {
+        } else if comment.lowercased().starts(with: "snippet.hide") {
             return SnippetVisibility.hidden
         } else {
             return nil

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetBuildTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetBuildTests.swift
@@ -32,10 +32,10 @@ class SnippetBuildTests: XCTestCase {
             print("Hello, world!")
         }
 
-        // MARK: Hide
+        // snippet.hide
         hidden()
 
-        // MARK: Show
+        // snippet.show
         shown()
         """
 
@@ -58,16 +58,16 @@ class SnippetBuildTests: XCTestCase {
     func testParseRedundantMarkers() {
         let source = """
         //! This is a snippet
-        // MARK: Show
+        // snippet.show
         func shown() {
             print("Hello, world!")
         }
 
-        // MARK: Hide
+        // snippet.hide
         hidden()
 
-        // MARK: Hide
-        // MARK: Show
+        // snippet.hide
+        // snippet.show
         shown()
         """
 
@@ -105,11 +105,11 @@ class SnippetBuildTests: XCTestCase {
     func testParseRemoveExtraIndentation() {
         do {
             let source = """
-            // MARK: Hide
+            // snippet.hide
             struct MyStruct {
-                // MARK: Show
+                // snippet.show
                 func foo()
-            // MARK: Hide
+            // snippet.hide
             }
             """
             let snippet = Snippet(parsing: source, sourceFile: fakeSourceFilename)
@@ -118,13 +118,13 @@ class SnippetBuildTests: XCTestCase {
         
         do {
             let source = """
-            // MARK: Hide
+            // snippet.hide
             struct Outer {
-                // MARK: Show
+                // snippet.show
                 struct Inner {
                     func foo()
                 }
-            // MARK: Hide
+            // snippet.hide
             }
             """
 
@@ -140,21 +140,21 @@ class SnippetBuildTests: XCTestCase {
 }
 
 class VisibilityMarkTests: XCTestCase {
-    func testParseMarkShow() {
-        XCTAssertEqual(.shown, "// mark: show".parsedVisibilityMark)
-        XCTAssertEqual(.shown, "// Mark: Show".parsedVisibilityMark)
-        XCTAssertEqual(.shown, "// MARK: Show".parsedVisibilityMark)
-        XCTAssertEqual(.shown, "//      MARK: Show".parsedVisibilityMark)
-        XCTAssertEqual(.shown, "//      MARK: Show    ".parsedVisibilityMark)
-        XCTAssertNil("MARK: Show".parsedVisibilityMark)
-    }
+    func testParseHideShow() {
+        XCTAssertEqual(.shown, "// snippet.show".parsedVisibilityMark)
+        XCTAssertEqual(.shown, "// Snippet.Show".parsedVisibilityMark)
+        XCTAssertEqual(.shown, "// SNIPPET.SHOW".parsedVisibilityMark)
+        XCTAssertEqual(.shown, "//      snippet.show".parsedVisibilityMark)
+        XCTAssertEqual(.shown, "//      snippet.show      ".parsedVisibilityMark)
 
-    func testParseMarkHide() {
-        XCTAssertEqual(.hidden, "// mark: hide".parsedVisibilityMark)
-        XCTAssertEqual(.hidden, "// Mark: Hide".parsedVisibilityMark)
-        XCTAssertEqual(.hidden, "// MARK: Hide".parsedVisibilityMark)
-        XCTAssertEqual(.hidden, "//      MARK: Hide".parsedVisibilityMark)
-        XCTAssertEqual(.hidden, "//      MARK: Hide   ".parsedVisibilityMark)
-        XCTAssertNil("MARK: Hide".parsedVisibilityMark)
+        XCTAssertEqual(.hidden, "// snippet.hide".parsedVisibilityMark)
+        XCTAssertEqual(.hidden, "// Snippet.Hide".parsedVisibilityMark)
+        XCTAssertEqual(.hidden, "// SNIPPET.HIDE".parsedVisibilityMark)
+        XCTAssertEqual(.hidden, "//      snippet.hide".parsedVisibilityMark)
+        XCTAssertEqual(.hidden, "//      snippet.hide   ".parsedVisibilityMark)
+
+        // Markers need to be a comment.
+        XCTAssertNil("snippet.show".parsedVisibilityMark)
+        XCTAssertNil("snippet.hide".parsedVisibilityMark)
     }
 }


### PR DESCRIPTION
Per required changes to SE-0356, move the MARK: Show/Hide markers
to `snippet.show` and `snippet.hide`.

rdar://95220141