### PR TITLE
Snippets: Implement SE-0356 changes to explanation parsing

### DIFF
--- a/IntegrationTests/Tests/Fixtures/PackageWithSnippets/_Snippets/TestTest.swift
+++ b/IntegrationTests/Tests/Fixtures/PackageWithSnippets/_Snippets/TestTest.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-//! Create a foo.
+// Create a foo.
 import Library
 
 let best = BestStruct()


### PR DESCRIPTION
Explanations no longer use the `//!` prefix but a regular,
uninterrupted list of `//` comments.

rdar://95220029