### PR TITLE
Allow test script to use upstream DocC.

### DIFF
--- a/bin/check-source
+++ b/bin/check-source
@@ -108,6 +108,8 @@ EOF
       \( \! -path '*/.build/*' -a \
       \! -name '.' -a \
       \( "${matching_files[@]}" \) -a \
+      \( \! -path './swift-docc/*' \) -a \
+      \( \! -path './swift-docc-render-artifact/*' \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
       if [[ "$(cat "$line" | replace_acceptable_years | $reader -n $expected_lines | $SHA_CMD)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"

--- a/bin/test
+++ b/bin/test
@@ -20,6 +20,41 @@ filepath() {
 # absolute file path to the Swift-DocC-Plugin root source dir.
 SWIFT_DOCC_PLUGIN_ROOT="$(dirname $(dirname $(filepath $0)))"
 
+SWIFT_DOCC_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc"
+SWIFT_DOCC_RENDER_ARTIFACT_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc-render-artifact"
+export DOCC_HTML_DIR="$SWIFT_DOCC_RENDER_ARTIFACT_ROOT/dist"
+
+SWIFT_DOCC_REPO=${SWIFT_DOCC_REPO:="https://github.com/apple/swift-docc.git"}
+SWIFT_DOCC_RENDER_ARTIFACT_REPO=${SWIFT_DOCC_RENDER_ARTIFACT_REPO:="https://github.com/apple/swift-docc-render-artifact.git"}
+
+SWIFT_DOCC_BRANCH=${SWIFT_DOCC_BRANCH:="main"}
+SWIFT_DOCC_RENDER_ARTIFACT_BRANCH=${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH:="main"}
+
+# The script will clone swift-docc and swift-docc-render-artifact at the
+# branches pulled from the environment above.  The tests will then run using
+# that built DocC. This can be useful for testing interdependent changes that
+# need to land together and make it possible to test multiple pull requests
+# together.
+
+echo "Cloning docc..."
+rm -rf "$SWIFT_DOCC_ROOT"
+git clone -b "$SWIFT_DOCC_BRANCH" "${SWIFT_DOCC_REPO}" "$SWIFT_DOCC_ROOT" || exit 1
+
+echo "Cloning docc-render-artifact..."
+rm -rf "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT"
+git clone -b "${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH}" "${SWIFT_DOCC_RENDER_ARTIFACT_REPO}" "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT" || exit 1
+
+echo "Building docc..."
+swift build --package-path "$SWIFT_DOCC_ROOT" --configuration release || exit 1
+
+export DOCC_EXEC="$(swift build --package-path "$SWIFT_DOCC_ROOT" --show-bin-path --configuration release)/docc"
+if [[ ! -f "$DOCC_EXEC" ]]; then
+  echo "docc executable not found, expected at $SWIFT_DOCC_EXEC"
+  exit 1
+else
+  echo "Using docc executable: $DOCC_EXEC"
+fi
+
 # Build and test Swift-DocC Plugin
 swift test --parallel --package-path "$SWIFT_DOCC_PLUGIN_ROOT"
 


### PR DESCRIPTION
Expect `SWIFT_DOCC_BRANCH` and `SWIFT_DOCC_RENDER_ARTIFACT_BRANCH` in the
environment. If both are set when running `./bin/test`, clone the respective
repos at those branches and set `DOCC_EXEC` and `DOCC_HTML_DIR` when running the
tests.

Exclude these cloned directories from `./bin/check-source`.

rdar://97294776