### PR TITLE
Added the option to skip building the upstream while running the test…

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -20,41 +20,45 @@ filepath() {
 # absolute file path to the Swift-DocC-Plugin root source dir.
 SWIFT_DOCC_PLUGIN_ROOT="$(dirname $(dirname $(filepath $0)))"
 
-SWIFT_DOCC_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc"
-SWIFT_DOCC_RENDER_ARTIFACT_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc-render-artifact"
-export DOCC_HTML_DIR="$SWIFT_DOCC_RENDER_ARTIFACT_ROOT/dist"
+SWIFT_SKIP_BUILDING_UPSTREAM_DOCC=${SWIFT_SKIP_BUILDING_UPSTREAM_DOCC:=false}
 
-SWIFT_DOCC_REPO=${SWIFT_DOCC_REPO:="https://github.com/apple/swift-docc.git"}
-SWIFT_DOCC_RENDER_ARTIFACT_REPO=${SWIFT_DOCC_RENDER_ARTIFACT_REPO:="https://github.com/apple/swift-docc-render-artifact.git"}
+if [[ $SWIFT_SKIP_BUILDING_UPSTREAM_DOCC != true ]]
+then
+  SWIFT_DOCC_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc"
+  SWIFT_DOCC_RENDER_ARTIFACT_ROOT="$SWIFT_DOCC_PLUGIN_ROOT/swift-docc-render-artifact"
+  export DOCC_HTML_DIR="$SWIFT_DOCC_RENDER_ARTIFACT_ROOT/dist"
 
-SWIFT_DOCC_BRANCH=${SWIFT_DOCC_BRANCH:="main"}
-SWIFT_DOCC_RENDER_ARTIFACT_BRANCH=${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH:="main"}
+  SWIFT_DOCC_REPO=${SWIFT_DOCC_REPO:="https://github.com/apple/swift-docc.git"}
+  SWIFT_DOCC_RENDER_ARTIFACT_REPO=${SWIFT_DOCC_RENDER_ARTIFACT_REPO:="https://github.com/apple/swift-docc-render-artifact.git"}
 
-# The script will clone swift-docc and swift-docc-render-artifact at the
-# branches pulled from the environment above.  The tests will then run using
-# that built DocC. This can be useful for testing interdependent changes that
-# need to land together and make it possible to test multiple pull requests
-# together.
+  SWIFT_DOCC_BRANCH=${SWIFT_DOCC_BRANCH:="main"}
+  SWIFT_DOCC_RENDER_ARTIFACT_BRANCH=${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH:="main"}
 
-echo "Cloning docc..."
-rm -rf "$SWIFT_DOCC_ROOT"
-git clone -b "$SWIFT_DOCC_BRANCH" "${SWIFT_DOCC_REPO}" "$SWIFT_DOCC_ROOT" || exit 1
+  # The script will clone swift-docc and swift-docc-render-artifact at the
+  # branches pulled from the environment above.  The tests will then run using
+  # that built DocC. This can be useful for testing interdependent changes that
+  # need to land together and make it possible to test multiple pull requests
+  # together.
 
-echo "Cloning docc-render-artifact..."
-rm -rf "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT"
-git clone -b "${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH}" "${SWIFT_DOCC_RENDER_ARTIFACT_REPO}" "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT" || exit 1
+  echo "Cloning docc..."
+  rm -rf "$SWIFT_DOCC_ROOT"
+  git clone -b "$SWIFT_DOCC_BRANCH" "${SWIFT_DOCC_REPO}" "$SWIFT_DOCC_ROOT" || exit 1
 
-echo "Building docc..."
-swift build --package-path "$SWIFT_DOCC_ROOT" --configuration release || exit 1
+  echo "Cloning docc-render-artifact..."
+  rm -rf "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT"
+  git clone -b "${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH}" "${SWIFT_DOCC_RENDER_ARTIFACT_REPO}" "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT" || exit 1
 
-export DOCC_EXEC="$(swift build --package-path "$SWIFT_DOCC_ROOT" --show-bin-path --configuration release)/docc"
-if [[ ! -f "$DOCC_EXEC" ]]; then
-  echo "docc executable not found, expected at $SWIFT_DOCC_EXEC"
-  exit 1
-else
-  echo "Using docc executable: $DOCC_EXEC"
+  echo "Building docc..."
+  swift build --package-path "$SWIFT_DOCC_ROOT" --configuration release || exit 1
+
+  export DOCC_EXEC="$(swift build --package-path "$SWIFT_DOCC_ROOT" --show-bin-path --configuration release)/docc"
+  if [[ ! -f "$DOCC_EXEC" ]]; then
+    echo "docc executable not found, expected at $SWIFT_DOCC_EXEC"
+    exit 1
+  else
+    echo "Using docc executable: $DOCC_EXEC"
+  fi
 fi
-
 # Build and test Swift-DocC Plugin
 swift test --parallel --package-path "$SWIFT_DOCC_PLUGIN_ROOT"
 


### PR DESCRIPTION
… script using an environment variable SWIFT_SKIP_BUILDING_UPSTREAM_DOCC

Bug/issue #, if applicable: 
Solves #22 
## Summary

Provides an option to skip cloning and building upstream docc and docc_render_artifact

## Dependencies

None

## Testing

Run the test with SWIFT_SKIP_BUILDING_UPSTREAM_DOCC set to true.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests - Not needed
- [ ] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
