### PR TITLE
Preview: remove use of `signal` on Windows

### DIFF
--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -6,6 +6,9 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+#if os(Windows)
+import WinSDK
+#endif
 import Foundation
 import PackagePlugin
 
@@ -125,6 +128,8 @@ import PackagePlugin
         func stopPreviewProcess() {
             #if os(macOS) && os(iOS) && os(tvOS) && os(watchOS)
             previewProcess.interrupt()
+            #elseif os(Windows)
+            _ = TerminateProcess(previewProcess.processHandle, 0)
             #else
             // On non-Darwin systems, `docc` doesn't properly exit with just an interrupt signal
             // so send a SIGKILL instead.


### PR DESCRIPTION
Windows does not support signal(2).  Instead, use `TerminateProcess` to
terminate the process.  We will not properly handle the termination of
child processes for the preview process, which should be handled by the
construction of a job object that all child processes are attached to
such that when the parent process is terminated, the children will be
properly reaped.  This is required to enable building the plugin on
Windows which is a dependency for swift-syntax.