### PR TITLE
Unwrap variables in a way Xcode 13 can be compiled

### DIFF
--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -42,7 +42,7 @@ extension Array where Element == Substring {
     }
     
     mutating func trimEmptyOrWhitespaceLines() {
-        while let last, last.isEmptyOrWhiteSpace {
+        while let last = last , last.isEmptyOrWhiteSpace {
             removeLast()
         }
         self = Array(drop { $0.isEmptyOrWhiteSpace })
@@ -89,7 +89,7 @@ struct SnippetParser {
     }
     
     mutating func endSlice() {
-        guard let currentSlice else {
+        guard let currentSlice = currentSlice else {
             return
         }
         guard currentSlice.startLine < presentationLines.count else {


### PR DESCRIPTION
Bug/issue: #30 

## Summary

Allows Documentation to be generated against Xcode 13

## Dependencies

N/A

## Testing

No new tests added, all current tests run and pass, no new functionality added

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
