### PR TITLE
Xcode 13 produces error `Cannot find type 'SnippetBuilder'` in scope

### DIFF
--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -53,7 +53,7 @@ import PackagePlugin
             workingDirectory: URL(fileURLWithPath: context.pluginWorkDirectory.string, isDirectory: true)
         )
 #else
-        let snippetExtractor: SnippetBuilder? = nil
+        let snippetExtractor: SnippetExtractor? = nil
 #endif
         
         


### PR DESCRIPTION
Bug/issue #, if applicable: #36 

## Summary

Fix for bug introduced in https://github.com/apple/swift-docc-plugin/commit/5f2e247f5efef4ff8ee603443a9a29225ce9f0e2 refactor, where `SnippetBuilder` had to be refactored to `SnippetExtractor`.

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
