### PR TITLE
Make snippet-extract take individual input/output files instead of a directory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,7 @@ let package = Package(
             dependencies: [
                 "Snippets",
                 "SwiftDocCPluginUtilities",
+                "snippet-extract",
             ],
             resources: [
                 .copy("Test Fixtures"),

--- a/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
+++ b/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
@@ -14,18 +14,19 @@ extension SymbolGraph.Symbol {
     /// Create a ``SymbolGraph.Symbol`` from a ``Snippet``.
     ///
     /// - parameter moduleName: The name to use for the package name in the snippet symbol's precise identifier.
-    public init(_ snippet: Snippets.Snippet, moduleName: String, inDirectory snippetsDirectory: URL) {
+    public init(_ snippet: Snippets.Snippet, moduleName: String) throws {
         let basename = snippet.sourceFile.deletingPathExtension().lastPathComponent
         let identifier = SymbolGraph.Symbol.Identifier(precise: "$snippet__\(moduleName).\(basename)", interfaceLanguage: "swift")
         let names = SymbolGraph.Symbol.Names.init(title: basename, navigator: nil, subHeading: nil, prose: nil)
         
         var pathComponents = snippet.sourceFile.absoluteURL.deletingPathExtension().pathComponents[...]
-        for component in snippetsDirectory.absoluteURL.pathComponents {
-            guard pathComponents.first == component else {
-                break
-            }
-            pathComponents = pathComponents.dropFirst(1)
+
+        guard let snippetsPathComponentIndex = pathComponents.firstIndex(where: {
+            $0 == "Snippets"
+        }) else {
+            throw SnippetExtractCommand.ArgumentError.snippetNotContainedInSnippetsDirectory(snippet.sourceFile)
         }
+        pathComponents = pathComponents[snippetsPathComponentIndex...]
         
         let docComment = SymbolGraph.LineList(snippet.explanation
                                     .split(separator: "\n", maxSplits: Int.max, omittingEmptySubsequences: false)

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
@@ -1,0 +1,33 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+
+@testable import Snippets
+import struct SymbolKit.SymbolGraph
+@testable import snippet_extract
+import XCTest
+
+class SnippetSymbolTests: XCTestCase {
+    func testThrowsErrorWhenCreatingFloatingSwiftSnippet() throws {
+        let source = """
+        // A snippet.
+        foo() {}
+        """
+        let snippet = Snippets.Snippet(parsing: source,
+                                       sourceFile: URL(fileURLWithPath: "/tmp/to/floating/File.swift"))
+        XCTAssertThrowsError(try SymbolGraph.Symbol(snippet, moduleName: "MyModule"),
+                             "Expected snippetNotContainedInSnippetsDirectory error",
+                             { (error: Error) in
+            guard let argumentError = error as? SnippetExtractCommand.ArgumentError,
+                  case .snippetNotContainedInSnippetsDirectory = argumentError else {
+                XCTFail("Expected snippetNotContainedInSnippetsDirectory error")
+                return
+            }
+        })
+    }
+}


### PR DESCRIPTION
This does not change the experience for package authors but allows for better integration with other tools that require sandboxing of file access.

rdar://103034070

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
