### PR TITLE
Prevent adding extra `Snippets` path component when converting to symbol graph symbols

### DIFF
--- a/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
+++ b/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
@@ -19,14 +19,18 @@ extension SymbolGraph.Symbol {
         let identifier = SymbolGraph.Symbol.Identifier(precise: "$snippet__\(moduleName).\(basename)", interfaceLanguage: "swift")
         let names = SymbolGraph.Symbol.Names.init(title: basename, navigator: nil, subHeading: nil, prose: nil)
         
-        var pathComponents = snippet.sourceFile.absoluteURL.deletingPathExtension().pathComponents[...]
+        var pathComponents = Array(snippet.sourceFile.absoluteURL.deletingPathExtension().pathComponents[...])
 
         guard let snippetsPathComponentIndex = pathComponents.firstIndex(where: {
             $0 == "Snippets"
         }) else {
             throw SnippetExtractCommand.ArgumentError.snippetNotContainedInSnippetsDirectory(snippet.sourceFile)
         }
-        pathComponents = pathComponents[snippetsPathComponentIndex...]
+
+        // In theory, there may be differently named snippet root directories in the future.
+        // Replace that path component with the standardized `Snippets`.
+        pathComponents.replaceSubrange(pathComponents.startIndex...snippetsPathComponentIndex,
+                                       with: CollectionOfOne("Snippets"))
         
         let docComment = SymbolGraph.LineList(snippet.explanation
                                     .split(separator: "\n", maxSplits: Int.max, omittingEmptySubsequences: false)
@@ -39,7 +43,7 @@ extension SymbolGraph.Symbol {
         
         self.init(identifier: identifier,
                   names: names,
-                  pathComponents: ["Snippets"] + Array(pathComponents),
+                  pathComponents: pathComponents,
                   docComment: docComment,
                   accessLevel: accessLevel,
                   kind: kind,

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
@@ -30,4 +30,15 @@ class SnippetSymbolTests: XCTestCase {
             }
         })
     }
+
+    func testPathComponentsForSnippetSymbol() throws {
+        let source = """
+        // A snippet.
+        foo() {}
+        """
+        let snippet = Snippets.Snippet(parsing: source,
+                                       sourceFile: URL(fileURLWithPath: "/path/to/my-package/Snippets/ASnippet.swift"))
+        let symbol = try SymbolGraph.Symbol(snippet, moduleName: "my-package")
+        XCTAssertEqual(["Snippets", "ASnippet"], symbol.pathComponents)
+    }
 }


### PR DESCRIPTION
rdar://104044227

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
