### PR TITLE
Only build the required `docc` executable product in CI

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -49,11 +49,11 @@ then
   git clone -b "${SWIFT_DOCC_RENDER_ARTIFACT_BRANCH}" "${SWIFT_DOCC_RENDER_ARTIFACT_REPO}" "$SWIFT_DOCC_RENDER_ARTIFACT_ROOT" || exit 1
 
   echo "Building docc..."
-  swift build --package-path "$SWIFT_DOCC_ROOT" --configuration release || exit 1
+  swift build --package-path "$SWIFT_DOCC_ROOT" --product docc --configuration release || exit 1
 
   export DOCC_EXEC="$(swift build --package-path "$SWIFT_DOCC_ROOT" --show-bin-path --configuration release)/docc"
   if [[ ! -f "$DOCC_EXEC" ]]; then
-    echo "docc executable not found, expected at $SWIFT_DOCC_EXEC"
+    echo "docc executable not found, expected at $DOCC_EXEC"
     exit 1
   else
     echo "Using docc executable: $DOCC_EXEC"


### PR DESCRIPTION
Resolves an issue where CI is failing with:

```
/swift-docc-plugin/swift-docc/Sources/generate-symbol-graph/main.swift:13:18: error: module 'SwiftDocC' was not compiled for testing
@testable import SwiftDocC
~~~~~~~~~~       ^
```

Caused by: https://github.com/apple/swift-docc/pull/447