### PR TITLE
Copy snippet symbol graphs to the correct final destination

### DIFF
--- a/IntegrationTests/Tests/SnippetDocumentationGenerationTests.swift
+++ b/IntegrationTests/Tests/SnippetDocumentationGenerationTests.swift
@@ -10,10 +10,11 @@ import XCTest
 
 final class SnippetDocumentationGenerationTests: ConcurrencyRequiringTestCase {
     func testGenerateDocumentationForPackageWithSnippets() throws {
+        let packageName = "PackageWithSnippets"
         let result = try swiftPackage(
             "generate-documentation",
             "--target", "Library",
-            workingDirectory: try setupTemporaryDirectoryForFixture(named: "PackageWithSnippets")
+            workingDirectory: try setupTemporaryDirectoryForFixture(named: packageName)
         )
 
         result.assertExitStatusEquals(0)
@@ -45,6 +46,19 @@ final class SnippetDocumentationGenerationTests: ConcurrencyRequiringTestCase {
                 "symbol-graphs/unified-symbol-graphs",
             ]
         )
+
+        let unifiedSymbolGraphDirectory = subDirectoriesOfSymbolGraphDirectory.first {
+            $0.pathComponents.last == "unified-symbol-graphs"
+        }!
+
+        let symbolGraphEnumerator = FileManager.default.enumerator(at: unifiedSymbolGraphDirectory,
+                                                                   includingPropertiesForKeys: [.isRegularFileKey])!
+        let symbolGraphPaths = try (symbolGraphEnumerator.allObjects as! [URL]).filter {
+            try $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile!
+        }
+        XCTAssertNotNil(symbolGraphPaths.first {
+            $0.pathComponents.last == "\(packageName)-snippets.symbols.json"
+        })
     }
 
     func testPreviewDocumentationWithSnippets() throws {

--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -13,22 +13,22 @@ extension PackageManager {
     struct DocCSymbolGraphResult {
         let unifiedSymbolGraphsDirectory: URL
         let targetSymbolGraphsDirectory: URL
-        let snippetSymbolGraphsDirectory: URL?
+        let snippetSymbolGraphFile: URL?
         
         init(
             unifiedSymbolGraphsDirectory: URL,
             targetSymbolGraphsDirectory: URL,
-            snippetSymbolGraphsDirectory: URL?
+            snippetSymbolGraphFile: URL?
         ) {
             self.unifiedSymbolGraphsDirectory = unifiedSymbolGraphsDirectory
             self.targetSymbolGraphsDirectory = targetSymbolGraphsDirectory
-            self.snippetSymbolGraphsDirectory = snippetSymbolGraphsDirectory
+            self.snippetSymbolGraphFile = snippetSymbolGraphFile
         }
         
         init(targetSymbolGraphsDirectory: URL) {
             self.unifiedSymbolGraphsDirectory = targetSymbolGraphsDirectory
             self.targetSymbolGraphsDirectory = targetSymbolGraphsDirectory
-            self.snippetSymbolGraphsDirectory = nil
+            self.snippetSymbolGraphFile = nil
         }
     }
     
@@ -70,7 +70,7 @@ extension PackageManager {
             print("snippet extractor provided, attempting to generate snippet symbol graph")
         }
         
-        guard let snippetSymbolGraphsDirectory = try snippetExtractor.generateSnippets(
+        guard let snippetSymbolGraphFile = try snippetExtractor.generateSnippets(
             for: target,
             context: context
         ) else {
@@ -82,7 +82,7 @@ extension PackageManager {
         }
         
         if verbose {
-            print("snippet symbol graph directory path: '\(snippetSymbolGraphsDirectory.path)'")
+            print("snippet symbol graph file: '\(snippetSymbolGraphFile.path)'")
         }
         
         // Since we successfully produced symbol graphs for snippets contained in the
@@ -125,20 +125,20 @@ extension PackageManager {
             toPath: targetSymbolGraphsUnifiedDirectory.path
         )
         
-        let snippetSymbolGraphsUnifiedDirectory = unifiedSymbolGraphsDirectory.appendingPathComponent(
-            "snippet-symbol-graphs", isDirectory: true
+        let snippetSymbolGraphFileInUnifiedDirectory = unifiedSymbolGraphsDirectory.appendingPathComponent(
+            snippetSymbolGraphFile.lastPathComponent, isDirectory: false
         )
         
         // Copy the snippet symbol graphs into the unified directory
         try FileManager.default.copyItem(
-            atPath: snippetSymbolGraphsDirectory.path,
-            toPath: snippetSymbolGraphsUnifiedDirectory.path
+            atPath: snippetSymbolGraphFile.path,
+            toPath: snippetSymbolGraphFileInUnifiedDirectory.path
         )
         
         return DocCSymbolGraphResult(
             unifiedSymbolGraphsDirectory: unifiedSymbolGraphsDirectory,
             targetSymbolGraphsDirectory: targetSymbolGraphsUnifiedDirectory,
-            snippetSymbolGraphsDirectory: snippetSymbolGraphsUnifiedDirectory
+            snippetSymbolGraphFile: snippetSymbolGraphFileInUnifiedDirectory
         )
     }
 }


### PR DESCRIPTION
The snippet symbol graph is currently being generated with the changes in e013865138b, however they are not being copied to the correct final destination.

The `snippet-extract` tool now takes input and output *files* instead of directories, however there is still one place in the plugin where we are still treating the output like a directory, so the snippet symbol graph basename path component looks like a directory, and needs additional basenames to put it in the right place with the correct file extension.

rdar://104045850

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
