### PR TITLE
Provide initializer for binding in guard for earlier Swift compatibility

### DIFF
--- a/Sources/snippet-extract/SnippetBuildCommand.swift
+++ b/Sources/snippet-extract/SnippetBuildCommand.swift
@@ -76,12 +76,12 @@ struct SnippetExtractCommand {
             }
         }
 
-        guard let parsedOutputFile else {
+        guard let parsedOutputFile = parsedOutputFile else {
             throw ArgumentError.missingOption(.outputFile)
         }
         self.outputFile = parsedOutputFile
 
-        guard let parsedModuleName else {
+        guard let parsedModuleName = parsedModuleName else {
             throw ArgumentError.missingOption(.moduleName)
         }
         self.moduleName = parsedModuleName


### PR DESCRIPTION
No functional change with this change. This allows the plugin to continue to build in Xcode 13.3.