### PR TITLE
Make --include-extended-types default for Swift 5.9

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -49,11 +49,17 @@ extension PackageManager {
         // Modify the symbol graph options with the custom ones
         for customSymbolGraphOption in customSymbolGraphOptions {
             switch customSymbolGraphOption {
-            case .extendedTypes:
+            case .extendedTypes.positive:
 #if swift(>=5.8)
                 symbolGraphOptions.emitExtensionBlocks = true
 #else
                 print("warning: detected '--include-extended-types' option, which is incompatible with your swift version (required: 5.8)")
+#endif
+            case .extendedTypes.negative:
+#if swift(>=5.8)
+                symbolGraphOptions.emitExtensionBlocks = false
+#else
+                print("warning: detected '--exclude-extended-types' option, which is incompatible with your swift version (required: 5.8)")
 #endif
             case .skipSynthesizedSymbols:
                 symbolGraphOptions.includeSynthesized = false

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -24,11 +24,17 @@ extension SwiftSourceModuleTarget {
             targetMinimumAccessLevel = .public
         }
         
+#if swift(>=5.9)
+        let emitExtensionBlockSymbolDefault = true
+#else
+        let emitExtensionBlockSymbolDefault = false
+#endif
+        
         return PackageManager.SymbolGraphOptions(
             minimumAccessLevel: targetMinimumAccessLevel,
             includeSynthesized: true,
             includeSPI: false,
-            emitExtensionBlocks: false
+            emitExtensionBlocks: emitExtensionBlockSymbolDefault
         )
     }
 }

--- a/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Generating Documentation for Extended Types.md
+++ b/Sources/SwiftDocCPluginDocumentation/SwiftDocCPlugin.docc/Generating Documentation for Extended Types.md
@@ -4,24 +4,26 @@ Generate documentation for the extensions you make to types from other modules.
 
 ## Overview
 
-By default, the Swift-DocC plugin ignores extensions you make to types that are not from the module you're generating documentation for.
+The Swift-DocC plugin allows you to document extensions you make to types that are not from the module you're generating documentation for.
 
-To include documentation for extended types, add the `--include-extended-types` flag to your invocations:
+To enable/disable extension support, add the `--include-extended-types` or `--exclude-extended-types` flag to your invocations, respectively:
 
     $ swift package generate-documentation --include-extended-types
 
-> Note: Extension support is available when using Swift 5.8 or later and the Swift-DocC plugin 1.2 or later.
+    $ swift package generate-documentation --exclude-extended-types
 
-## Understanding What is Included by Default
+> Note: Extension support is available when using Swift 5.8 or later and the Swift-DocC plugin 1.2 or later. Extension support is enabled by default starting swith Swift 5.9 and the Swift-DocC plugin 1.3.
 
-Not everything that is declared in an extension is hidden behind the `--include-extended-types` flag. If the extension is declared in the same target as the type it is extending, the extension's contents will be included in the documentation by default.
+## Understanding What is an Extended Type
+
+Not every type you add an extension to is an extended type. If the extension is declared in the same target as the type it is extending, the extension's contents will always be included in the documentation. Only extensions you make to types from other targets are represented as an external type in your documentation archive.
 
 ```swift
 public struct Sloth { }
 
 extension Sloth {
-    // This function is included in the
-    // documentation by default.
+    // This function is always included
+    // in the documentation.
     public func wake() { /* ... */ }
 }
 
@@ -29,8 +31,9 @@ extension Sloth {
 // not the `SlothCreator` library, so this is
 // what we call an "extended type".
 extension Collection where Element == Sloth {
-    // This property is not included in
-    // the documentation by default.
+    // This property is only included in
+    // the documentation if extension
+    // support is enabled.
     public func wake() {
         for sloth in self {
             sloth.wake()

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -56,8 +56,13 @@ public enum HelpInformation {
 #endif
         
         for flag in supportedPluginFlags {
+            var flagListText = flag.positive.parsedValues.sorted().joined(separator: ", ")
+            if !flag.negative.parsedValues.isEmpty {
+                flagListText += " / \(flag.negative.parsedValues.sorted().joined(separator: ", "))"
+            }
+            
             helpText += """
-                  \(flag.parsedValues.sorted().joined(separator: ", "))
+                  \(flagListText)
                                           \(flag.abstract)
                         \(flag.description)
                 

--- a/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
@@ -156,8 +156,8 @@ public struct ParsedArguments {
         
         let symbolGraphArguments = arguments.filter(for: .dumpSymbolGraph)
         
-        self.symbolGraphArguments = ParsedArguments.ArgumentConsumer.dumpSymbolGraph.flags.filter { option in
-            option.parsedValues.contains(where: symbolGraphArguments.contains)
+        self.symbolGraphArguments = ParsedArguments.ArgumentConsumer.dumpSymbolGraph.flags.compactMap {
+            $0.value(for: symbolGraphArguments)
         }
     }
     

--- a/Sources/SwiftDocCPluginUtilities/PluginFlags/ExtendedTypesFlag.swift
+++ b/Sources/SwiftDocCPluginUtilities/PluginFlags/ExtendedTypesFlag.swift
@@ -7,9 +7,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 extension PluginFlag {
-    /// Include extended types in documentation archives.
+    /// Include or exclude extended types in documentation archives.
     ///
-    /// Enables the extension block symbol format when calling the
+    /// Enables/disables the extension block symbol format when calling the
     /// dump symbol graph API.
     ///
     /// - Note: This flag is only available starting from Swift 5.8. It should
@@ -17,13 +17,20 @@ extension PluginFlag {
     /// However, we do not hide the flag entirely, because this enables us to give
     /// a more precise warning when accidentally used with Swift 5.7 or lower.
     static let extendedTypes = PluginFlag(
-        parsedValues: [
+        positiveValues: [
             "--include-extended-types",
         ],
-        abstract: "Include extended types from other modules in the produced DocC archive.",
-        description: """
-            Allows documenting symbols that a target adds to its dependencies.
-            """,
+        negativeValues: [
+            "--exclude-extended-types",
+        ],
+        abstract: "Control whether extended types from other modules are shown in the produced DocC archive. (default: \(Self.default))",
+        description: "Allows documenting symbols that a target adds to its dependencies.",
         argumentTransformation: { $0 }
     )
+    
+#if swift(>=5.9)
+    private static let `default` = "--include-extended-types"
+#else
+    private static let `default` = "--exclude-extended-types"
+#endif
 }

--- a/Sources/SwiftDocCPluginUtilities/PluginFlags/PluginFlag+Equatable.swift
+++ b/Sources/SwiftDocCPluginUtilities/PluginFlags/PluginFlag+Equatable.swift
@@ -8,6 +8,7 @@
 
 extension PluginFlag: Equatable {
     static func ==(lhs: PluginFlag, rhs: PluginFlag) -> Bool {
-        return lhs.parsedValues == rhs.parsedValues
+        return lhs.positive.parsedValues == rhs.positive.parsedValues
+        && lhs.negative.parsedValues == rhs.negative.parsedValues
     }
 }

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -42,7 +42,7 @@ final class HelpInformationTests: XCTestCase {
                     Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
               --experimental-skip-synthesized-symbols
                                       Exclude synthesized symbols from the generated documentation
-                    Experimental feature that produces a DocC archive without compiler synthesized symbols.\(includeExtendedTypesSection)
+                    Experimental feature that produces a DocC archive without compiler synthesized symbols.\(extendedTypesSection)
 
             DOCC OPTIONS:
               --platform <platform>   Set the current release version of a platform.
@@ -134,7 +134,7 @@ final class HelpInformationTests: XCTestCase {
                     Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
               --experimental-skip-synthesized-symbols
                                       Exclude synthesized symbols from the generated documentation
-                    Experimental feature that produces a DocC archive without compiler synthesized symbols.\(includeExtendedTypesSection)
+                    Experimental feature that produces a DocC archive without compiler synthesized symbols.\(extendedTypesSection)
             
             DOCC OPTIONS:
               --platform <platform>   Set the current release version of a platform.
@@ -191,12 +191,18 @@ final class HelpInformationTests: XCTestCase {
 }
 
 #if swift(>=5.8)
-private let includeExtendedTypesSection = """
+private let extendedTypesSection = """
 
-  --include-extended-types
-                          Include extended types from other modules in the produced DocC archive.
+  --include-extended-types / --exclude-extended-types
+                          Control whether extended types from other modules are shown in the produced DocC archive. (default: \(extendedTypesDefault))
         Allows documenting symbols that a target adds to its dependencies.
 """
 #else
-private let includeExtendedTypesSection = ""
+private let extendedTypesSection = ""
+#endif
+
+#if swift(>=5.9)
+private let extendedTypesDefault = "--include-extended-types"
+#else
+private let extendedTypesDefault = "--exclude-extended-types"
 #endif

--- a/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
@@ -460,9 +460,19 @@ final class ParsedArgumentsTests: XCTestCase {
     }
     
     func testDumpSymbolGraphArguments() {
-        let dumpSymbolGraphArguments = ParsedArguments(["--include-extended-types", "--experimental-skip-synthesized-symbols"])
+        var dumpSymbolGraphArguments: ParsedArguments
         
-        XCTAssertEqual(dumpSymbolGraphArguments.symbolGraphArguments, [.extendedTypes, .skipSynthesizedSymbols])
+        dumpSymbolGraphArguments = ParsedArguments(["--include-extended-types", "--experimental-skip-synthesized-symbols"])
+        XCTAssertEqual(dumpSymbolGraphArguments.symbolGraphArguments, [.extendedTypes.positive, .skipSynthesizedSymbols])
+        
+        dumpSymbolGraphArguments = ParsedArguments(["--exclude-extended-types", "--experimental-skip-synthesized-symbols"])
+        XCTAssertEqual(dumpSymbolGraphArguments.symbolGraphArguments, [.extendedTypes.negative, .skipSynthesizedSymbols])
+        
+        dumpSymbolGraphArguments = ParsedArguments(["--include-extended-types", "--experimental-skip-synthesized-symbols", "--exclude-extended-types"])
+        XCTAssertEqual(dumpSymbolGraphArguments.symbolGraphArguments, [.extendedTypes.negative, .skipSynthesizedSymbols])
+        
+        dumpSymbolGraphArguments = ParsedArguments(["--exclude-extended-types", "--include-extended-types"])
+        XCTAssertEqual(dumpSymbolGraphArguments.symbolGraphArguments, [.extendedTypes.positive])
     }
     
     func testDumpSymbolGraphArgumentsWithDocCArguments() {

--- a/Tests/SwiftDocCPluginUtilitiesTests/PluginFlags/ExtendedTypesFlagTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/PluginFlags/ExtendedTypesFlagTests.swift
@@ -20,6 +20,51 @@ final class ExtendedTypesFlagTests: XCTestCase {
         )
     }
     
+    func testReplacesExcludeExtendedTypesFlagWhenPresent() {
+        XCTAssertEqual(
+            PluginFlag.extendedTypes.transform(
+                ["--exclude-extended-types", "--other-flag"]
+            ),
+            ["--other-flag"]
+        )
+    }
+    
+    func testPositiveReplacesIncludeExtendedTypesFlag() {
+        XCTAssertEqual(
+            PluginFlag.extendedTypes.positive.transform(
+                ["--include-extended-types", "--other-flag"]
+            ),
+            ["--other-flag"]
+        )
+    }
+    
+    func testNegativeReplacesExcludeExtendedTypesFlag() {
+        XCTAssertEqual(
+            PluginFlag.extendedTypes.negative.transform(
+                ["--exclude-extended-types", "--other-flag"]
+            ),
+            ["--other-flag"]
+        )
+    }
+    
+    func testPositiveDoesNotReplaceExcludeExtendedTypesFlag() {
+        XCTAssertEqual(
+            PluginFlag.extendedTypes.positive.transform(
+                ["--exclude-extended-types", "--other-flag"]
+            ),
+            ["--exclude-extended-types", "--other-flag"]
+        )
+    }
+    
+    func testNegativeDoesNotReplaceIncludeExtendedTypesFlag() {
+        XCTAssertEqual(
+            PluginFlag.extendedTypes.negative.transform(
+                ["--include-extended-types", "--other-flag"]
+            ),
+            ["--include-extended-types", "--other-flag"]
+        )
+    }
+    
     func testDoesNotAddEmitExtensionBlockSymbolsFlagWhenAbsent() {
         XCTAssertEqual(
             PluginFlag.extendedTypes.transform(


### PR DESCRIPTION
Bug/issue #, if applicable: apple/swift-docc#210

## Summary

This PR makes `--include-extended-types` the default behavior for handling extended types when compiled with a Swift version greater or equal to 5.9. It also introduces the negative counterpart flag `--exclude-extended-types`, which is available from Swift 5.8. The default behavior for Swift 5.8 remains unchanged (equivalent to `--exclude-extended-types`).

The DocC documentation for the Plugin has been reworded.

The relevant part of the help text generated by the plugin's help flag has been reworded and shown both flags (`--include-extended-types` and `--exclude-extended-types`) along with the default value. The text is the same for Swift 5.8 and Swift 5.9, except for the default value.

## Dependencies

None.

## Testing

There are unit and integration tests making sure the behavior and help text is as expected for the Swift version the tests are run with. I ran the full `bin/test` suite with a Swift 5.7, Swift 5.8, and Swift 5.9 toolchain each and tested invocations manually  with the same toolchains on a local test target.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
