### PR TITLE
Replace os() with canImport(Darwin)

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
@@ -33,7 +33,7 @@ extension Package {
                     addTargets(product.targets)
                 case .target(let target):
                     addTargets([target])
-                #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+                #if canImport(Darwin)
                 @unknown default:
                     return
                 #endif

--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -127,7 +127,7 @@ import PackagePlugin
         
         
         func stopPreviewProcess() {
-            #if os(macOS) && os(iOS) && os(tvOS) && os(watchOS)
+            #if canImport(Darwin)
             previewProcess.interrupt()
             #elseif os(Windows)
             _ = TerminateProcess(previewProcess.processHandle, 0)

--- a/Sources/SwiftDocCPluginUtilities/DispatchTimeInterval+descriptionInSeconds.swift
+++ b/Sources/SwiftDocCPluginUtilities/DispatchTimeInterval+descriptionInSeconds.swift
@@ -28,7 +28,7 @@ extension DispatchTimeInterval {
             return String(format: "%.2f", Double(value)/Double(1_000_000_000)) + "s"
         case .never:
             return "n/a"
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if canImport(Darwin)
         @unknown default:
             return "n/a"
         #endif


### PR DESCRIPTION
## Summary

_Provide a description of what your PR addresses, explaining the expected user experience. 

I updated the `#if os()` usage for Apple's platform to a better solution as `#if canImport(Darwin)`. With this solution, there's no need to add one more `os(xrOS)`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Ran the `./bin/test` script and it succeeded

I didn't implement anything new, so no documentation is needed to be updated neither implementing additional tests.
