### PR TITLE
Documenting local debug/test workflows in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ let package = Package(
     // name, platforms, products, etc.
     dependencies: [
         // other dependencies
-        .package(url: "path/to/local/swift-docc-plugin", from: "1.1.0"),
+        .package(path: "path/to/local/swift-docc-plugin"),
     ],
     targets: [
         // targets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,10 @@ on [Swift.org](https://www.swift.org/download/#snapshots).
     swift package generate-documentation
     ```
 
-### Using your local Swift-DocC Plugin as a Dependency
+### Using your local Swift-DocC plugin as a dependency
 
 If you want to debug a change, you can use your local development version of
-Swift-DocC plugin by specifying a local path in your project's `Package.swift`
-dependency:
+the Swift-DocC plugin by specifying a local path in your project's `Package.swift`:
 
 ```swift
 let package = Package(
@@ -111,12 +110,13 @@ let package = Package(
 ### Using your local Swift-DocC
 
 By default, Swift-DocC plugin will run `docc` from your Swift toolchain.
-However, if you're working on Swift-DocC, and want to test your `docc` with
+However, if you're working on Swift-DocC, and want to test your in-development `docc` with
 Swift-DocC plugin, you can set the `DOCC_EXEC` environment variable before
 invoking the plugin:
 
 ```bash
-DOCC_EXEC=path/to/swift-docc/.build/debug/docc swift package generate-documentation
+export DOCC_EXEC=path/to/swift-docc/.build/debug/docc
+swift package generate-documentation
 ```
 
 ## Code Contribution Guidelines
@@ -173,7 +173,7 @@ If you do not have commit access, please ask one of the code owners to trigger t
 For more details on Swift-DocC's continuous integration, see the
 [Continous Integration](#continuous-integration) section below.
 
-## Testing Swift-DocC Plugin
+## Testing the Swift-DocC plugin
 
 The Swift-DocC plugin is committed to maintaining a high level of code quality.
 Before opening a pull request, we ask that you:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ from the community.
 ### Contributing Code and Documentation
 
 Before contributing code or documentation to the Swift-DocC plugin,
-we encourage you to first create an issue on [Swift JIRA](https://bugs.swift.org/).
+we encourage you to first open a [GitHub issue](https://github.com/apple/swift-docc-plugin/issues/new/choose).
 This will allow us to provide feedback on the proposed change.
 However, this is not a requirement. If your contribution is small in scope,
 feel free to open a PR without first creating an issue.
@@ -49,12 +49,12 @@ more details.
 
 ### Prerequisites
 
-The Swift-DocC plugin is a SwiftPM command plugin package. 
+The Swift-DocC plugin is a SwiftPM command plugin package.
 If you're new to Swift package manager,
 the [documentation here](https://swift.org/getting-started#using-the-package-manager)
 provides an explanation of how to get started and the software you'll need installed.
 
-Note that Swift 5.6 is required in order to run the plugin. 
+Note that Swift 5.6 is required in order to run the plugin.
 Development snapshots that include Swift 5.6 can be found
 on [Swift.org](https://www.swift.org/download/#snapshots).
 
@@ -94,7 +94,7 @@ on [Swift.org](https://www.swift.org/download/#snapshots).
 ### Overview
 
 - Do your best to keep the git history easy to understand.
-  
+
 - Use informative commit titles and descriptions.
   - Include a brief summary of changes as the first line.
   - Describe everything that was added, removed, or changed, and why.
@@ -121,11 +121,10 @@ requirements:
 When opening a pull request, please make sure to fill out the pull request template
 and complete all tasks mentioned there.
 
-Your PR should mention the number of the [Swift JIRA](https://bugs.swift.org/)
-issue your work is addressing (SR-NNNNN).
-  
-Most PRs should be against the `main` branch. If your change is intended 
-for a specific release, you should also create a separate branch 
+Your PR should mention the number of the GitHub issue your work is addressing.
+
+Most PRs should be against the `main` branch. If your change is intended
+for a specific release, you should also create a separate branch
 that cherry-picks your commit onto the associated release branch.
 
 ### Code Review Process
@@ -165,10 +164,10 @@ automated testing in CI as well.
 
 The Swift-DocC plugin maintains two test suites. Whenever possible, new code should be added
 to the `SwiftDocCPluginUtilities` library instead of directly to a plugin. This allows the logic to be
-unit tested within `SwiftDocCPluginUtilitiesTests`. 
+unit tested within `SwiftDocCPluginUtilitiesTests`.
 
-Integration tests can be added to the `IntegrationTests` sub-package that is a part of this repo. 
-This allows for writing end-to-end tests that invoke both the Swift Package Manager and Swift-DocC 
+Integration tests can be added to the `IntegrationTests` sub-package that is a part of this repo.
+This allows for writing end-to-end tests that invoke both the Swift Package Manager and Swift-DocC
 to ensure the plugin is functioning as expected.
 
 ### Using Docker to Test Swift-DocC Plugin for Linux
@@ -195,7 +194,7 @@ by running the test suite in a Docker environment that simulates Swift on Linux.
     ```bash
     docker run -v `pwd`:/swift-docc-plugin swift-docc-plugin sh -c "cd /swift-docc-plugin && ./bin/test"
     ```
-    
+
 ## Continuous Integration
 
 Swift-DocC plugin uses [swift-ci](https://ci.swift.org) infrastructure for its continuous integration
@@ -208,23 +207,23 @@ If you do not have commit access, please ask one of the code owners to trigger t
     ```
     @swift-ci Please test
     ```
-    
+
     <details>
      <summary>Platform specific instructions:</summary>
-     
+
      1. Run the project's unit tests on **macOS**, along with a selection of compatibility suite
         tests by commenting the following:
-     
+
          ```
          @swift-ci Please test macOS platform
          ```
-     
+
      2. Run the project's unit tests on **Linux** by commenting the following:
-     
+
          ```
          @swift-ci Please test Linux platform
          ```
-     
+
     </details>
-    
+
 <!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,36 @@ on [Swift.org](https://www.swift.org/download/#snapshots).
     swift package generate-documentation
     ```
 
+### Using your local Swift-DocC Plugin as a Dependency
+
+If you want to debug a change, you can use your local development version of
+Swift-DocC plugin by specifying a local path in your project's `Package.swift`
+dependency:
+
+```swift
+let package = Package(
+    // name, platforms, products, etc.
+    dependencies: [
+        // other dependencies
+        .package(url: "path/to/local/swift-docc-plugin", from: "1.1.0"),
+    ],
+    targets: [
+        // targets
+    ]
+)
+```
+
+### Using your local Swift-DocC
+
+By default, Swift-DocC plugin will run `docc` from your Swift toolchain.
+However, if you're working on Swift-DocC, and want to test your `docc` with
+Swift-DocC plugin, you can set the `DOCC_EXEC` environment variable before
+invoking the plugin:
+
+```bash
+DOCC_EXEC=path/to/swift-docc/.build/debug/docc swift package generate-documentation
+```
+
 ## Code Contribution Guidelines
 
 ### Overview
@@ -143,7 +173,7 @@ If you do not have commit access, please ask one of the code owners to trigger t
 For more details on Swift-DocC's continuous integration, see the
 [Continous Integration](#continuous-integration) section below.
 
-## Testing Swift-DocC
+## Testing Swift-DocC Plugin
 
 The Swift-DocC plugin is committed to maintaining a high level of code quality.
 Before opening a pull request, we ask that you:


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

This pull-request updates CONTRIBUTING.md: 
- Changes mentions of Swift JIRA to GitHub, consistent with [Swift-DocC repo](https://github.com/apple/swift-docc/blob/main/CONTRIBUTING.md)
- Documents how to use local `swift-docc-plugin` in other Swift packages.
- Documents how to use local `docc` from the plugin.

Related to https://github.com/apple/swift-docc/pull/653 — once @ethan-kusters reviewd that one, I asked if I should clean `swift-docc-plugin` to be consistent as well.

## Dependencies

No code changes, so no dependencies.
