### PR TITLE
Suppress warnings on Windows too

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageExtensions.swift
@@ -33,10 +33,8 @@ extension Package {
                     addTargets(product.targets)
                 case .target(let target):
                     addTargets([target])
-                #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
                 @unknown default:
                     return
-                #endif
                 }
             }
         }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

When I build on Windows, I get multiple copies of this warning:

```
C:\Users\dave\src\hylo\.build\checkouts\swift-docc-plugin\Plugins\Swift-DocC Convert\Symbolic Links\SharedPackagePluginExtensions\PackageExtensions.swift:31:17: warning: switch covers known cases, but 'TargetDependency' may have additional unknown values
                switch dependency {
                ^
```

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [-] Added tests **Nothing new to test**
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
