### PR TITLE
Include all DocC help options in the plugin help

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ If you have commit access, you can run the required tests by commenting the foll
 
 If you do not have commit access, please ask one of the code owners to trigger them for you.
 For more details on Swift-DocC's continuous integration, see the
-[Continous Integration](#continuous-integration) section below.
+[Continuous Integration](#continuous-integration) section below.
 
 ## Testing the Swift-DocC plugin
 
@@ -256,4 +256,4 @@ If you do not have commit access, please ask one of the code owners to trigger t
 
     </details>
 
-<!-- Copyright (c) 2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2022-2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -69,14 +69,15 @@ public enum HelpInformation {
                 """
         }
         
-        let doccHelp = try _doccHelp(pluginAction, doccExecutableURL)
-        
-        if let doccOptions = doccHelp?.components(separatedBy: "OPTIONS:\n").last {
-            helpText += """
-
-                DOCC OPTIONS:
-                \(doccOptions)
-                """
+        if let doccHelp = try _doccHelp(pluginAction, doccExecutableURL) {
+            let doccHelpOptions = doccHelp.components(separatedBy: "\n\n")
+                .drop(while: { !$0.hasPrefix("USAGE: ")})
+                .dropFirst()
+            
+            helpText = helpText.trimmingCharacters(in: .newlines) + doccHelpOptions.map { 
+                // Join the DocC Options again and prefix each options group with DOCC to separate them from the plugin options
+                "\n\n" + ($0.first?.isLetter == true ? "DOCC " : "") + $0
+            }.joined()
         }
         
         return helpText.trimmingCharacters(in: .newlines) + "\n"

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -44,51 +44,101 @@ final class HelpInformationTests: XCTestCase {
                                       Exclude synthesized symbols from the generated documentation
                     Experimental feature that produces a DocC archive without compiler synthesized symbols.\(extendedTypesSection)
 
-            DOCC OPTIONS:
-              --platform <platform>   Set the current release version of a platform.
-                    Use the following format: "name={platform name},version={semantic version}".
-              --analyze               Outputs additional analyzer style warnings in addition to standard warnings/errors.
-              --emit-digest           Writes additional metadata files to the output directory.
-              --index                 Writes the navigator index to the output directory.
-              --emit-fixits/--no-emit-fixits
-                                      Outputs fixits for common issues (default: false)
+            DOCC INPUTS & OUTPUTS:
+              <catalog-path>          Path to a '.docc' documentation catalog directory.
+              --additional-symbol-graph-dir <additional-symbol-graph-dir>
+                                      A path to a directory of additional symbol graph files.
+              -o, --output-path, --output-dir <output-path>
+                                      The location where the documentation compiler writes the built documentation.
+
+            DOCC AVAILABILITY OPTIONS:
+              --platform <platform>   Specify information about the current release of a platform.
+                    Each platform's information is specified via separate "--platform" values using the following format: "name={platform name},version={semantic version}".
+                    Optionally, the platform information can include a 'beta={true|false}' component. If no beta information is provided, the platform is considered not in beta.
+
+            DOCC SOURCE REPOSITORY OPTIONS:
+              --checkout-path <checkout-path>
+                                      The root path on disk of the repository's checkout.
+              --source-service <source-service>
+                                      The source code service used to host the project's sources.
+                    Required when using '--source-service-base-url'. Supported values are 'github', 'gitlab', and 'bitbucket'.
+              --source-service-base-url <source-service-base-url>
+                                      The base URL where the source service hosts the project's sources.
+                    Required when using '--source-service'. For example, 'https://github.com/my-org/my-repo/blob/main'.
+
+            DOCC HOSTING OPTIONS:
+              --hosting-base-path <hosting-base-path>
+                                      The base path your documentation website will be hosted at.
+                    For example, if you deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.
+              --transform-for-static-hosting/--no-transform-for-static-hosting
+                                      Produce a DocC archive that supports static hosting environments. (default: --transform-for-static-hosting)
+
+            DOCC DIAGNOSTIC OPTIONS:
+              --analyze               Include 'note'/'information' level diagnostics in addition to warnings and errors.
+              --diagnostics-file, --diagnostics-output-path <diagnostics-file>
+                                      The location where the documentation compiler writes the diagnostics file.
+                    Specifying a diagnostic file path implies '--ide-console-output'.
+              --diagnostic-filter, --diagnostic-level <diagnostic-filter>
+                                      Filter diagnostics with a lower severity than this level.
+                    This option is ignored if `--analyze` is passed.
+
+                    This filter level is inclusive. If a level of 'note' is specified, diagnostics with a severity up to and including 'note' will be printed.
+                    The supported diagnostic filter levels are:
+                     - error
+                     - warning
+                     - note, info, information
+                     - hint, notice
+              --ide-console-output, --emit-fixits
+                                      Format output to the console intended for an IDE or other tool to parse.
+              --warnings-as-errors    Treat warnings as errors
+
+            DOCC INFO.PLIST FALLBACKS:
+              --default-code-listing-language <default-code-listing-language>
+                                      A fallback default language for code listings if no value is provided in the documentation catalogs's Info.plist file.
+              --fallback-display-name, --display-name <fallback-display-name>
+                                      A fallback display name if no value is provided in the documentation catalogs's Info.plist file.
+                    If no display name is provided in the catalogs's Info.plist file or via the '--fallback-display-name' option, DocC will infer a display name from the documentation catalog base name or from the module name
+                    from the symbol graph files provided via the '--additional-symbol-graph-dir' option.
+              --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
+                                      A fallback bundle identifier if no value is provided in the documentation catalogs's Info.plist file.
+                    If no bundle identifier is provided in the catalogs's Info.plist file or via the '--fallback-bundle-identifier' option, DocC will infer a bundle identifier from the display name.
+              --fallback-default-module-kind <fallback-default-module-kind>
+                                      A fallback default module kind if no value is provided in the documentation catalogs's Info.plist file.
+                    If no module kind is provided in the catalogs's Info.plist file or via the '--fallback-default-module-kind' option, DocC will display the module kind as a "Framework".
+
+            DOCC DOCUMENTATION COVERAGE (EXPERIMENTAL):
               --experimental-documentation-coverage
-                                      Generates documentation coverage output. (currently Experimental)
-              --level <level>         Desired level of documentation coverage output. (default: none)
-              --kinds <kind>          The kinds of entities to filter generated documentation for.
+                                      Generate documentation coverage output.
+                    Detailed documentation coverage information will be written to 'documentation-coverage.json' in the output directory.
+              --coverage-summary-level <symbol-kind>
+                                      The level of documentation coverage information to write on standard out. (default: brief)
+                    The '--coverage-summary-level' level has no impact on the information in the 'documentation-coverage.json' file.
+                    The supported coverage summary levels are 'brief' and 'detailed'.
+              --coverage-symbol-kind-filter <symbol-kind>
+                                      Filter documentation coverage to only analyze symbols of the specified symbol kinds.
+                    Specify a list of symbol kind values to filter the documentation coverage to only those types symbols.
+                    The supported symbol kind values are: associated-type, class, dictionary, enumeration, enumeration-case, function, global-variable, http-request, initializer, instance-method, instance-property,
+                    instance-subcript, instance-variable, module, operator, protocol, structure, type-alias, type-method, type-property, type-subscript, typedef
+
+            DOCC LINK RESOLUTION OPTIONS (EXPERIMENTAL):
+              --dependency <dependency>
+                                      A path to a documentation archive to resolve external links against.
+                    Only documentation archives built with '--enable-experimental-external-link-support' are supported as dependencies.
+
+            DOCC FEATURE FLAGS:
               --experimental-enable-custom-templates
                                       Allows for custom templates, like `header.html`.
               --enable-inherited-docs Inherit documentation for inherited symbols
-              --fallback-display-name, --display-name <fallback-display-name>
-                                      A fallback display name if no value is provided in the documentation bundle's Info.plist file.
-              --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
-                                      A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist
-                                      file.
-              --fallback-bundle-version, --bundle-version <fallback-bundle-version>
-                                      A fallback bundle version if no value is provided in the documentation bundle's Info.plist
-                                      file.
-              --default-code-listing-language <default-code-listing-language>
-                                      A fallback default language for code listings if no value is provided in the documentation
-                                      bundle's Info.plist file.
-              --fallback-default-module-kind <fallback-default-module-kind>
-                                      A fallback default module kind if no value is provided in the documentation bundle's
-                                      Info.plist file.
-              --output-path, --output-dir <output-path>
-                                      The location where the documentation compiler writes the built documentation.
-              --additional-symbol-graph-dir <additional-symbol-graph-dir>
-                                      A path to a directory of additional symbol graph files.
-              --diagnostic-level <diagnostic-level>
-                                      Filters diagnostics above this level from output
-                    This filter level is inclusive. If a level of `information` is specified, diagnostics with a severity up to and
-                    including `information` will be printed.
-                    This option is ignored if `--analyze` is passed.
-                    Must be one of "error", "warning", "information", or "hint"
-              --transform-for-static-hosting
-                                      Produce a Swift-DocC Archive that supports a static hosting environment.
-              --hosting-base-path <hosting-base-path>
-                                      The base path your documentation website will be hosted at.
-                    For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of
-                    'example.com/documentation', pass '/my_name/my_project' as the base path.
+              --allow-arbitrary-catalog-directories
+                                      Experimental: allow catalog directories without the `.docc` extension.
+              --enable-experimental-external-link-support
+                                      Support external links to this documentation output.
+                    Write additional link metadata files to the output directory to support resolving documentation links to the documentation in that output directory.
+              --emit-digest           Write additional metadata files to the output directory.
+              --emit-lmdb-index       Writes an LMDB representation of the navigator index to the output directory.
+                    A JSON representation of the navigator index is emitted by default.
+
+            DOCC OPTIONS:
               -h, --help              Show help information.
 
             """
@@ -136,53 +186,87 @@ final class HelpInformationTests: XCTestCase {
                                       Exclude synthesized symbols from the generated documentation
                     Experimental feature that produces a DocC archive without compiler synthesized symbols.\(extendedTypesSection)
             
-            DOCC OPTIONS:
-              --platform <platform>   Set the current release version of a platform.
-                    Use the following format: "name={platform name},version={semantic version}".
-              --analyze               Outputs additional analyzer style warnings in addition to standard warnings/errors.
-              --emit-digest           Writes additional metadata files to the output directory.
-              --index                 Writes the navigator index to the output directory.
-              --emit-fixits/--no-emit-fixits
-                                      Outputs fixits for common issues (default: false)
+            DOCC PREVIEW OPTIONS:
+              -p, --port <port-number>
+                                      Port number to use for the preview web server. (default: 8080)
+              <catalog-path>          Path to a '.docc' documentation catalog directory.
+              --additional-symbol-graph-dir <additional-symbol-graph-dir>
+                                      A path to a directory of additional symbol graph files.
+              -o, --output-path, --output-dir <output-path>
+                                      The location where the documentation compiler writes the built documentation.
+              --platform <platform>   Specify information about the current release of a platform.
+                    Each platform's information is specified via separate "--platform" values using the following format: "name={platform name},version={semantic version}".
+                    Optionally, the platform information can include a 'beta={true|false}' component. If no beta information is provided, the platform is considered not in beta.
+              --checkout-path <checkout-path>
+                                      The root path on disk of the repository's checkout.
+              --source-service <source-service>
+                                      The source code service used to host the project's sources.
+                    Required when using '--source-service-base-url'. Supported values are 'github', 'gitlab', and 'bitbucket'.
+              --source-service-base-url <source-service-base-url>
+                                      The base URL where the source service hosts the project's sources.
+                    Required when using '--source-service'. For example, 'https://github.com/my-org/my-repo/blob/main'.
+              --hosting-base-path <hosting-base-path>
+                                      The base path your documentation website will be hosted at.
+                    For example, if you deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.
+              --transform-for-static-hosting/--no-transform-for-static-hosting
+                                      Produce a DocC archive that supports static hosting environments. (default: --transform-for-static-hosting)
+              --analyze               Include 'note'/'information' level diagnostics in addition to warnings and errors.
+              --diagnostics-file, --diagnostics-output-path <diagnostics-file>
+                                      The location where the documentation compiler writes the diagnostics file.
+                    Specifying a diagnostic file path implies '--ide-console-output'.
+              --diagnostic-filter, --diagnostic-level <diagnostic-filter>
+                                      Filter diagnostics with a lower severity than this level.
+                    This option is ignored if `--analyze` is passed.
+
+                    This filter level is inclusive. If a level of 'note' is specified, diagnostics with a severity up to and including 'note' will be printed.
+                    The supported diagnostic filter levels are:
+                     - error
+                     - warning
+                     - note, info, information
+                     - hint, notice
+              --ide-console-output, --emit-fixits
+                                      Format output to the console intended for an IDE or other tool to parse.
+              --warnings-as-errors    Treat warnings as errors
+              --default-code-listing-language <default-code-listing-language>
+                                      A fallback default language for code listings if no value is provided in the documentation catalogs's Info.plist file.
+              --fallback-display-name, --display-name <fallback-display-name>
+                                      A fallback display name if no value is provided in the documentation catalogs's Info.plist file.
+                    If no display name is provided in the catalogs's Info.plist file or via the '--fallback-display-name' option, DocC will infer a display name from the documentation catalog base name or from the module name
+                    from the symbol graph files provided via the '--additional-symbol-graph-dir' option.
+              --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
+                                      A fallback bundle identifier if no value is provided in the documentation catalogs's Info.plist file.
+                    If no bundle identifier is provided in the catalogs's Info.plist file or via the '--fallback-bundle-identifier' option, DocC will infer a bundle identifier from the display name.
+              --fallback-default-module-kind <fallback-default-module-kind>
+                                      A fallback default module kind if no value is provided in the documentation catalogs's Info.plist file.
+                    If no module kind is provided in the catalogs's Info.plist file or via the '--fallback-default-module-kind' option, DocC will display the module kind as a "Framework".
               --experimental-documentation-coverage
-                                      Generates documentation coverage output. (currently Experimental)
-              --level <level>         Desired level of documentation coverage output. (default: none)
-              --kinds <kind>          The kinds of entities to filter generated documentation for.
+                                      Generate documentation coverage output.
+                    Detailed documentation coverage information will be written to 'documentation-coverage.json' in the output directory.
+              --coverage-summary-level <symbol-kind>
+                                      The level of documentation coverage information to write on standard out. (default: brief)
+                    The '--coverage-summary-level' level has no impact on the information in the 'documentation-coverage.json' file.
+                    The supported coverage summary levels are 'brief' and 'detailed'.
+              --coverage-symbol-kind-filter <symbol-kind>
+                                      Filter documentation coverage to only analyze symbols of the specified symbol kinds.
+                    Specify a list of symbol kind values to filter the documentation coverage to only those types symbols.
+                    The supported symbol kind values are: associated-type, class, dictionary, enumeration, enumeration-case, function, global-variable, http-request, initializer, instance-method, instance-property,
+                    instance-subcript, instance-variable, module, operator, protocol, structure, type-alias, type-method, type-property, type-subscript, typedef
+              --dependency <dependency>
+                                      A path to a documentation archive to resolve external links against.
+                    Only documentation archives built with '--enable-experimental-external-link-support' are supported as dependencies.
               --experimental-enable-custom-templates
                                       Allows for custom templates, like `header.html`.
               --enable-inherited-docs Inherit documentation for inherited symbols
-              --fallback-display-name, --display-name <fallback-display-name>
-                                      A fallback display name if no value is provided in the documentation bundle's Info.plist file.
-              --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
-                                      A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist
-                                      file.
-              --fallback-bundle-version, --bundle-version <fallback-bundle-version>
-                                      A fallback bundle version if no value is provided in the documentation bundle's Info.plist
-                                      file.
-              --default-code-listing-language <default-code-listing-language>
-                                      A fallback default language for code listings if no value is provided in the documentation
-                                      bundle's Info.plist file.
-              --fallback-default-module-kind <fallback-default-module-kind>
-                                      A fallback default module kind if no value is provided in the documentation bundle's
-                                      Info.plist file.
-              --output-path, --output-dir <output-path>
-                                      The location where the documentation compiler writes the built documentation.
-              --additional-symbol-graph-dir <additional-symbol-graph-dir>
-                                      A path to a directory of additional symbol graph files.
-              --diagnostic-level <diagnostic-level>
-                                      Filters diagnostics above this level from output
-                    This filter level is inclusive. If a level of `information` is specified, diagnostics with a severity up to and
-                    including `information` will be printed.
-                    This option is ignored if `--analyze` is passed.
-                    Must be one of "error", "warning", "information", or "hint"
-              --transform-for-static-hosting
-                                      Produce a Swift-DocC Archive that supports a static hosting environment.
-              --hosting-base-path <hosting-base-path>
-                                      The base path your documentation website will be hosted at.
-                    For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of
-                    'example.com/documentation', pass '/my_name/my_project' as the base path.
-              -p, --port <port-number>
-                                      Port number to use for the preview web server. (default: 8000)
+              --allow-arbitrary-catalog-directories
+                                      Experimental: allow catalog directories without the `.docc` extension.
+              --enable-experimental-external-link-support
+                                      Support external links to this documentation output.
+                    Write additional link metadata files to the output directory to support resolving documentation links to the documentation in that output directory.
+              --emit-digest           Write additional metadata files to the output directory.
+              --emit-lmdb-index       Writes an LMDB representation of the navigator index to the output directory.
+                    A JSON representation of the navigator index is emitted by default.
+
+            DOCC OPTIONS:
               -h, --help              Show help information.
             
             """

--- a/Tests/SwiftDocCPluginUtilitiesTests/Test Fixtures/DocCConvertHelpFixture.txt
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Test Fixtures/DocCConvertHelpFixture.txt
@@ -1,54 +1,107 @@
-OVERVIEW: Converts documentation from a source bundle.
+OVERVIEW: Convert documentation markup, assets, and symbol information into a documentation archive.
 
-USAGE: docc convert [<options>] <source-bundle-path>
+When building documentation for source code, the 'convert' command is commonly invoked by other tools as part of a build workflow. Such build workflows can perform tasks to extract symbol graph information and may
+infer values for 'docc' flags and options from other build configuration.
 
-ARGUMENTS:
-  <source-bundle-path>    Path to a documentation bundle directory.
-        The '.docc' bundle docc will build.
+When building documentation for a catalog that only contain articles or tutorial content, interacting with the 'docc convert' command directly can be a good alternative to using DocC via a build workflow.
 
-OPTIONS:
-  --platform <platform>   Set the current release version of a platform.
-        Use the following format: "name={platform name},version={semantic version}".
-  --analyze               Outputs additional analyzer style warnings in addition to standard warnings/errors.
-  --emit-digest           Writes additional metadata files to the output directory.
-  --index                 Writes the navigator index to the output directory.
-  --emit-fixits/--no-emit-fixits
-                          Outputs fixits for common issues (default: false)
+USAGE: docc convert [<catalog-path>] [--additional-symbol-graph-dir <symbol-graph-dir>]
+       docc convert [<catalog-path>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>]
+       docc convert [<catalog-path>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>] [<availability-options>] [<diagnostic-options>] [<source-repository-options>] [<hosting-options>] [<info-plist-fallbacks>] [<feature-flags>] [<other-options>]
+
+INPUTS & OUTPUTS:
+  <catalog-path>          Path to a '.docc' documentation catalog directory.
+  --additional-symbol-graph-dir <additional-symbol-graph-dir>
+                          A path to a directory of additional symbol graph files.
+  -o, --output-path, --output-dir <output-path>
+                          The location where the documentation compiler writes the built documentation.
+
+AVAILABILITY OPTIONS:
+  --platform <platform>   Specify information about the current release of a platform.
+        Each platform's information is specified via separate "--platform" values using the following format: "name={platform name},version={semantic version}".
+        Optionally, the platform information can include a 'beta={true|false}' component. If no beta information is provided, the platform is considered not in beta.
+
+SOURCE REPOSITORY OPTIONS:
+  --checkout-path <checkout-path>
+                          The root path on disk of the repository's checkout.
+  --source-service <source-service>
+                          The source code service used to host the project's sources.
+        Required when using '--source-service-base-url'. Supported values are 'github', 'gitlab', and 'bitbucket'.
+  --source-service-base-url <source-service-base-url>
+                          The base URL where the source service hosts the project's sources.
+        Required when using '--source-service'. For example, 'https://github.com/my-org/my-repo/blob/main'.
+
+HOSTING OPTIONS:
+  --hosting-base-path <hosting-base-path>
+                          The base path your documentation website will be hosted at.
+        For example, if you deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.
+  --transform-for-static-hosting/--no-transform-for-static-hosting
+                          Produce a DocC archive that supports static hosting environments. (default: --transform-for-static-hosting)
+
+DIAGNOSTIC OPTIONS:
+  --analyze               Include 'note'/'information' level diagnostics in addition to warnings and errors.
+  --diagnostics-file, --diagnostics-output-path <diagnostics-file>
+                          The location where the documentation compiler writes the diagnostics file.
+        Specifying a diagnostic file path implies '--ide-console-output'.
+  --diagnostic-filter, --diagnostic-level <diagnostic-filter>
+                          Filter diagnostics with a lower severity than this level.
+        This option is ignored if `--analyze` is passed.
+
+        This filter level is inclusive. If a level of 'note' is specified, diagnostics with a severity up to and including 'note' will be printed.
+        The supported diagnostic filter levels are:
+         - error
+         - warning
+         - note, info, information
+         - hint, notice
+  --ide-console-output, --emit-fixits
+                          Format output to the console intended for an IDE or other tool to parse.
+  --warnings-as-errors    Treat warnings as errors
+
+INFO.PLIST FALLBACKS:
+  --default-code-listing-language <default-code-listing-language>
+                          A fallback default language for code listings if no value is provided in the documentation catalogs's Info.plist file.
+  --fallback-display-name, --display-name <fallback-display-name>
+                          A fallback display name if no value is provided in the documentation catalogs's Info.plist file.
+        If no display name is provided in the catalogs's Info.plist file or via the '--fallback-display-name' option, DocC will infer a display name from the documentation catalog base name or from the module name
+        from the symbol graph files provided via the '--additional-symbol-graph-dir' option.
+  --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
+                          A fallback bundle identifier if no value is provided in the documentation catalogs's Info.plist file.
+        If no bundle identifier is provided in the catalogs's Info.plist file or via the '--fallback-bundle-identifier' option, DocC will infer a bundle identifier from the display name.
+  --fallback-default-module-kind <fallback-default-module-kind>
+                          A fallback default module kind if no value is provided in the documentation catalogs's Info.plist file.
+        If no module kind is provided in the catalogs's Info.plist file or via the '--fallback-default-module-kind' option, DocC will display the module kind as a "Framework".
+
+DOCUMENTATION COVERAGE (EXPERIMENTAL):
   --experimental-documentation-coverage
-                          Generates documentation coverage output. (currently Experimental)
-  --level <level>         Desired level of documentation coverage output. (default: none)
-  --kinds <kind>          The kinds of entities to filter generated documentation for.
+                          Generate documentation coverage output.
+        Detailed documentation coverage information will be written to 'documentation-coverage.json' in the output directory.
+  --coverage-summary-level <symbol-kind>
+                          The level of documentation coverage information to write on standard out. (default: brief)
+        The '--coverage-summary-level' level has no impact on the information in the 'documentation-coverage.json' file.
+        The supported coverage summary levels are 'brief' and 'detailed'.
+  --coverage-symbol-kind-filter <symbol-kind>
+                          Filter documentation coverage to only analyze symbols of the specified symbol kinds.
+        Specify a list of symbol kind values to filter the documentation coverage to only those types symbols.
+        The supported symbol kind values are: associated-type, class, dictionary, enumeration, enumeration-case, function, global-variable, http-request, initializer, instance-method, instance-property,
+        instance-subcript, instance-variable, module, operator, protocol, structure, type-alias, type-method, type-property, type-subscript, typedef
+
+LINK RESOLUTION OPTIONS (EXPERIMENTAL):
+  --dependency <dependency>
+                          A path to a documentation archive to resolve external links against.
+        Only documentation archives built with '--enable-experimental-external-link-support' are supported as dependencies.
+
+FEATURE FLAGS:
   --experimental-enable-custom-templates
                           Allows for custom templates, like `header.html`.
   --enable-inherited-docs Inherit documentation for inherited symbols
-  --fallback-display-name, --display-name <fallback-display-name>
-                          A fallback display name if no value is provided in the documentation bundle's Info.plist file.
-  --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
-                          A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist
-                          file.
-  --fallback-bundle-version, --bundle-version <fallback-bundle-version>
-                          A fallback bundle version if no value is provided in the documentation bundle's Info.plist
-                          file.
-  --default-code-listing-language <default-code-listing-language>
-                          A fallback default language for code listings if no value is provided in the documentation
-                          bundle's Info.plist file.
-  --fallback-default-module-kind <fallback-default-module-kind>
-                          A fallback default module kind if no value is provided in the documentation bundle's
-                          Info.plist file.
-  --output-path, --output-dir <output-path>
-                          The location where the documentation compiler writes the built documentation.
-  --additional-symbol-graph-dir <additional-symbol-graph-dir>
-                          A path to a directory of additional symbol graph files.
-  --diagnostic-level <diagnostic-level>
-                          Filters diagnostics above this level from output
-        This filter level is inclusive. If a level of `information` is specified, diagnostics with a severity up to and
-        including `information` will be printed.
-        This option is ignored if `--analyze` is passed.
-        Must be one of "error", "warning", "information", or "hint"
-  --transform-for-static-hosting
-                          Produce a Swift-DocC Archive that supports a static hosting environment.
-  --hosting-base-path <hosting-base-path>
-                          The base path your documentation website will be hosted at.
-        For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of
-        'example.com/documentation', pass '/my_name/my_project' as the base path.
+  --allow-arbitrary-catalog-directories
+                          Experimental: allow catalog directories without the `.docc` extension.
+  --enable-experimental-external-link-support
+                          Support external links to this documentation output.
+        Write additional link metadata files to the output directory to support resolving documentation links to the documentation in that output directory.
+  --emit-digest           Write additional metadata files to the output directory.
+  --emit-lmdb-index       Writes an LMDB representation of the navigator index to the output directory.
+        A JSON representation of the navigator index is emitted by default.
+
+OPTIONS:
   -h, --help              Show help information.

--- a/Tests/SwiftDocCPluginUtilitiesTests/Test Fixtures/DocCPreviewHelpFixture.txt
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Test Fixtures/DocCPreviewHelpFixture.txt
@@ -1,56 +1,90 @@
-OVERVIEW: Previews documentation from a source bundle.
+OVERVIEW: Convert documentation inputs and preview the documentation output.
 
-USAGE: docc preview [<options>] <source-bundle-path>
+The 'preview' command extends the 'convert' command by running a preview server and monitoring the documentation input for modifications to rebuild the documentation.
 
-ARGUMENTS:
-  <source-bundle-path>    Path to a documentation bundle directory.
-        The '.docc' bundle docc will build.
+USAGE: docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>]
+       docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>]
+       docc preview [<catalog-path>] [--port <port-number>] [--additional-symbol-graph-dir <symbol-graph-dir>] [--output-dir <output-dir>] [<availability-options>] [<diagnostic-options>] [<source-repository-options>] [<hosting-options>] [<info-plist-fallbacks>] [<feature-flags>] [<other-options>]
 
-OPTIONS:
-  --platform <platform>   Set the current release version of a platform.
-        Use the following format: "name={platform name},version={semantic version}".
-  --analyze               Outputs additional analyzer style warnings in addition to standard warnings/errors.
-  --emit-digest           Writes additional metadata files to the output directory.
-  --index                 Writes the navigator index to the output directory.
-  --emit-fixits/--no-emit-fixits
-                          Outputs fixits for common issues (default: false)
+PREVIEW OPTIONS:
+  -p, --port <port-number>
+                          Port number to use for the preview web server. (default: 8080)
+  <catalog-path>          Path to a '.docc' documentation catalog directory.
+  --additional-symbol-graph-dir <additional-symbol-graph-dir>
+                          A path to a directory of additional symbol graph files.
+  -o, --output-path, --output-dir <output-path>
+                          The location where the documentation compiler writes the built documentation.
+  --platform <platform>   Specify information about the current release of a platform.
+        Each platform's information is specified via separate "--platform" values using the following format: "name={platform name},version={semantic version}".
+        Optionally, the platform information can include a 'beta={true|false}' component. If no beta information is provided, the platform is considered not in beta.
+  --checkout-path <checkout-path>
+                          The root path on disk of the repository's checkout.
+  --source-service <source-service>
+                          The source code service used to host the project's sources.
+        Required when using '--source-service-base-url'. Supported values are 'github', 'gitlab', and 'bitbucket'.
+  --source-service-base-url <source-service-base-url>
+                          The base URL where the source service hosts the project's sources.
+        Required when using '--source-service'. For example, 'https://github.com/my-org/my-repo/blob/main'.
+  --hosting-base-path <hosting-base-path>
+                          The base path your documentation website will be hosted at.
+        For example, if you deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.
+  --transform-for-static-hosting/--no-transform-for-static-hosting
+                          Produce a DocC archive that supports static hosting environments. (default: --transform-for-static-hosting)
+  --analyze               Include 'note'/'information' level diagnostics in addition to warnings and errors.
+  --diagnostics-file, --diagnostics-output-path <diagnostics-file>
+                          The location where the documentation compiler writes the diagnostics file.
+        Specifying a diagnostic file path implies '--ide-console-output'.
+  --diagnostic-filter, --diagnostic-level <diagnostic-filter>
+                          Filter diagnostics with a lower severity than this level.
+        This option is ignored if `--analyze` is passed.
+
+        This filter level is inclusive. If a level of 'note' is specified, diagnostics with a severity up to and including 'note' will be printed.
+        The supported diagnostic filter levels are:
+         - error
+         - warning
+         - note, info, information
+         - hint, notice
+  --ide-console-output, --emit-fixits
+                          Format output to the console intended for an IDE or other tool to parse.
+  --warnings-as-errors    Treat warnings as errors
+  --default-code-listing-language <default-code-listing-language>
+                          A fallback default language for code listings if no value is provided in the documentation catalogs's Info.plist file.
+  --fallback-display-name, --display-name <fallback-display-name>
+                          A fallback display name if no value is provided in the documentation catalogs's Info.plist file.
+        If no display name is provided in the catalogs's Info.plist file or via the '--fallback-display-name' option, DocC will infer a display name from the documentation catalog base name or from the module name
+        from the symbol graph files provided via the '--additional-symbol-graph-dir' option.
+  --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
+                          A fallback bundle identifier if no value is provided in the documentation catalogs's Info.plist file.
+        If no bundle identifier is provided in the catalogs's Info.plist file or via the '--fallback-bundle-identifier' option, DocC will infer a bundle identifier from the display name.
+  --fallback-default-module-kind <fallback-default-module-kind>
+                          A fallback default module kind if no value is provided in the documentation catalogs's Info.plist file.
+        If no module kind is provided in the catalogs's Info.plist file or via the '--fallback-default-module-kind' option, DocC will display the module kind as a "Framework".
   --experimental-documentation-coverage
-                          Generates documentation coverage output. (currently Experimental)
-  --level <level>         Desired level of documentation coverage output. (default: none)
-  --kinds <kind>          The kinds of entities to filter generated documentation for.
+                          Generate documentation coverage output.
+        Detailed documentation coverage information will be written to 'documentation-coverage.json' in the output directory.
+  --coverage-summary-level <symbol-kind>
+                          The level of documentation coverage information to write on standard out. (default: brief)
+        The '--coverage-summary-level' level has no impact on the information in the 'documentation-coverage.json' file.
+        The supported coverage summary levels are 'brief' and 'detailed'.
+  --coverage-symbol-kind-filter <symbol-kind>
+                          Filter documentation coverage to only analyze symbols of the specified symbol kinds.
+        Specify a list of symbol kind values to filter the documentation coverage to only those types symbols.
+        The supported symbol kind values are: associated-type, class, dictionary, enumeration, enumeration-case, function, global-variable, http-request, initializer, instance-method, instance-property,
+        instance-subcript, instance-variable, module, operator, protocol, structure, type-alias, type-method, type-property, type-subscript, typedef
+  --dependency <dependency>
+                          A path to a documentation archive to resolve external links against.
+        Only documentation archives built with '--enable-experimental-external-link-support' are supported as dependencies.
   --experimental-enable-custom-templates
                           Allows for custom templates, like `header.html`.
   --enable-inherited-docs Inherit documentation for inherited symbols
-  --fallback-display-name, --display-name <fallback-display-name>
-                          A fallback display name if no value is provided in the documentation bundle's Info.plist file.
-  --fallback-bundle-identifier, --bundle-identifier <fallback-bundle-identifier>
-                          A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist
-                          file.
-  --fallback-bundle-version, --bundle-version <fallback-bundle-version>
-                          A fallback bundle version if no value is provided in the documentation bundle's Info.plist
-                          file.
-  --default-code-listing-language <default-code-listing-language>
-                          A fallback default language for code listings if no value is provided in the documentation
-                          bundle's Info.plist file.
-  --fallback-default-module-kind <fallback-default-module-kind>
-                          A fallback default module kind if no value is provided in the documentation bundle's
-                          Info.plist file.
-  --output-path, --output-dir <output-path>
-                          The location where the documentation compiler writes the built documentation.
-  --additional-symbol-graph-dir <additional-symbol-graph-dir>
-                          A path to a directory of additional symbol graph files.
-  --diagnostic-level <diagnostic-level>
-                          Filters diagnostics above this level from output
-        This filter level is inclusive. If a level of `information` is specified, diagnostics with a severity up to and
-        including `information` will be printed.
-        This option is ignored if `--analyze` is passed.
-        Must be one of "error", "warning", "information", or "hint"
-  --transform-for-static-hosting
-                          Produce a Swift-DocC Archive that supports a static hosting environment.
-  --hosting-base-path <hosting-base-path>
-                          The base path your documentation website will be hosted at.
-        For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of
-        'example.com/documentation', pass '/my_name/my_project' as the base path.
-  -p, --port <port-number>
-                          Port number to use for the preview web server. (default: 8000)
+  --allow-arbitrary-catalog-directories
+                          Experimental: allow catalog directories without the `.docc` extension.
+  --enable-experimental-external-link-support
+                          Support external links to this documentation output.
+        Write additional link metadata files to the output directory to support resolving documentation links to the documentation in that output directory.
+  --emit-digest           Write additional metadata files to the output directory.
+  --emit-lmdb-index       Writes an LMDB representation of the navigator index to the output directory.
+        A JSON representation of the navigator index is emitted by default.
+
+OPTIONS:
   -h, --help              Show help information.


### PR DESCRIPTION
Bug/issue #, if applicable: #71

## Summary

This update the processing of the DocC help text to include all the DocC option groups and not just the last one.

Since there are multiple option groups in recent versions of DocC, the option groups from DocC are prefixed with "DOCC" to distinguish them from the option groups from the plugin.

## Dependencies

None.

## Testing

Compare the output from `docc convert --help` (from a local `main` build or recent main development toolchain) with the output from `swift package plugin generate-documentation -h`.

All DocC options should be included in the plugin help text.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] ~Added~ Updated tests
- [x] Ran the `./bin/test` script and it succeeded
- ~[ ] Updated documentation if necessary~
