### PR TITLE
Fix typos

### DIFF
--- a/Sources/SwiftDocCPluginUtilities/Snippets/SnippetExtractor.swift
+++ b/Sources/SwiftDocCPluginUtilities/Snippets/SnippetExtractor.swift
@@ -93,7 +93,7 @@ public class SnippetExtractor {
     /// function multiple times with the same package identifier.
     ///
     /// - Parameters:
-    ///   - packageIdentifier: A unique identifier for the packge.
+    ///   - packageIdentifier: A unique identifier for the package.
     ///   - packageDisplayName: A display name for the package.
     ///   - packageDirectory: The root directory for this package.
     ///

--- a/Sources/snippet-extract/SnippetBuildCommand.swift
+++ b/Sources/snippet-extract/SnippetBuildCommand.swift
@@ -50,7 +50,7 @@ struct SnippetExtractCommand {
 
             ARGUMENTS:
                 <output file> (Required)
-                    The path of the output Symbol Graph JSON file representing the snippets for the a module or package
+                    The path of the output Symbol Graph JSON file representing the snippets for the module or package
                 <module name> (Required)
                     The module name to use for the Symbol Graph (typically should be the package name)
                 <input files>


### PR DESCRIPTION
## Summary

Fix two minor typos in SnippetExtractor.swift and SnippetBuildCommand.swift. No code changes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (Not applicable.)
- [x] Ran the `./bin/test` script and it succeeded
- [ ] ~~Updated documentation if necessary~~ (Not applicable.)
