### PR TITLE
add `.vscode` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm
 /gh-pages
 Package.resolved
+.vscode


### PR DESCRIPTION
Bug/issue #, if applicable: N/A

## Summary

This PR adds the `.vscode` to the `.gitignore` file to exclude vs code configuration files from contributors using VS Code.

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] <s>Added tests</s> Unit testing unnecessary
- [x] Ran the `./bin/test` script and it succeeded
- [x] <s>Updated documentation if necessary</s> Documenting this change is unnecessary
