### PR TITLE
Add new symbol graph generation option for include/skip inherited docs

### DIFF
--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -60,7 +60,7 @@ extension PackageManager {
         }
 
         if let skipInheritedDocs = customSymbolGraphOptions.skipInheritedDocs {
-#if swift(<6.3)
+#if compiler(<6.3)
             print("warning: detected '--skip-inherited-docs' option, which is incompatible with your swift version (required: 6.3)")
 #else
             symbolGraphOptions.includeInheritedDocs = !skipInheritedDocs

--- a/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
+++ b/Plugins/SharedPackagePluginExtensions/PackageManager+getSymbolGraphsForDocC.swift
@@ -58,6 +58,14 @@ extension PackageManager {
         if customSymbolGraphOptions.skipSynthesizedSymbols == true {
             symbolGraphOptions.includeSynthesized = false
         }
+
+        if let skipInheritedDocs = customSymbolGraphOptions.skipInheritedDocs {
+#if swift(<6.3)
+            print("warning: detected '--skip-inherited-docs' option, which is incompatible with your swift version (required: 6.3)")
+#else
+            symbolGraphOptions.includeInheritedDocs = !skipInheritedDocs
+#endif
+        }
         
         if let includeExtendedTypes = customSymbolGraphOptions.includeExtendedTypes {
 #if swift(<5.8)

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -24,7 +24,7 @@ extension SourceModuleTarget {
             targetMinimumAccessLevel = .public
         }
 
-#if swift(<6.3)
+#if compiler(<6.3)
         let skipInheritedDocs = false
 #endif
         
@@ -44,7 +44,7 @@ extension SourceModuleTarget {
     }
 }
 
-#if swift(<6.3)
+#if compiler(<6.3)
 private extension PackageManager.SymbolGraphOptions {
     /// A compatibility layer for lower Swift versions which don't toggle include/skip inherited docs.
     init(minimumAccessLevel: PackagePlugin.PackageManager.SymbolGraphOptions.AccessLevel = .public,

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -24,9 +24,7 @@ extension SourceModuleTarget {
             targetMinimumAccessLevel = .public
         }
 
-#if compiler(<6.3)
         let skipInheritedDocs = false
-#endif
         
 #if swift(>=5.9)
         let emitExtensionBlockSymbolDefault = true

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2022-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,10 @@ extension SourceModuleTarget {
             // the 'public' minimum access level.
             targetMinimumAccessLevel = .public
         }
+
+#if swift(>=6.3)
+        let skipInheritedDocs = false
+#endif
         
 #if swift(>=5.9)
         let emitExtensionBlockSymbolDefault = true
@@ -32,12 +36,26 @@ extension SourceModuleTarget {
         
         return PackageManager.SymbolGraphOptions(
             minimumAccessLevel: targetMinimumAccessLevel,
+            includeInheritedDocs: !skipInheritedDocs,
             includeSynthesized: true,
             includeSPI: false,
             emitExtensionBlocks: emitExtensionBlockSymbolDefault
         )
     }
 }
+
+#if swift(<6.3)
+private extension PackageManager.SymbolGraphOptions {
+    /// A compatibility layer for lower Swift versions which don't toggle include/skip inherited docs.
+    init(minimumAccessLevel: PackagePlugin.PackageManager.SymbolGraphOptions.AccessLevel = .public,
+         includeInheritedDocs: Bool = true
+         includeSynthesized: Bool = false,
+         includeSPI: Bool = false,
+         emitExtensionBlocks: Bool) {
+        self.init(minimumAccessLevel: minimumAccessLevel, includeSynthesized: includeSynthesized, includeSPI: includeSPI, emitExtensionBlocks: emitExtensionBlocks)
+    }
+}
+#endif
 
 
 #if swift(<5.8)

--- a/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
+++ b/Plugins/SharedPackagePluginExtensions/Target+defaultSymbolGraphOptions.swift
@@ -24,7 +24,7 @@ extension SourceModuleTarget {
             targetMinimumAccessLevel = .public
         }
 
-#if swift(>=6.3)
+#if swift(<6.3)
         let skipInheritedDocs = false
 #endif
         
@@ -48,7 +48,7 @@ extension SourceModuleTarget {
 private extension PackageManager.SymbolGraphOptions {
     /// A compatibility layer for lower Swift versions which don't toggle include/skip inherited docs.
     init(minimumAccessLevel: PackagePlugin.PackageManager.SymbolGraphOptions.AccessLevel = .public,
-         includeInheritedDocs: Bool = true
+         includeInheritedDocs: Bool = true,
          includeSynthesized: Bool = false,
          includeSPI: Bool = false,
          emitExtensionBlocks: Bool) {

--- a/Sources/SwiftDocCPluginUtilities/CommandLineArguments/ParsedPluginArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/CommandLineArguments/ParsedPluginArguments.swift
@@ -35,12 +35,14 @@ struct ParsedSymbolGraphArguments {
     var minimumAccessLevel: String?
     var skipSynthesizedSymbols: Bool?
     var includeExtendedTypes: Bool?
+    var skipInheritedDocs: Bool?
     
     /// Creates a new symbol graph arguments container by extracting the known plugin values from a command line argument list.
     init(extractingFrom arguments: inout CommandLineArguments) {
         minimumAccessLevel     = arguments.extractOption(.minimumAccessLevel)
         skipSynthesizedSymbols = arguments.extractFlag(.skipSynthesizedSymbols)
         includeExtendedTypes   = arguments.extractFlag(.extendedTypes)
+        skipInheritedDocs      = arguments.extractFlag(.skipInheritedDocs)
     }
 }
 

--- a/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
@@ -125,7 +125,7 @@ extension DocumentedArgument {
         flag: .init(preferred: "--skip-inherited-docs"),
         abstract: "Skip inherited docs from parent class or protocol members.",
         discussion: """
-            Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
+            Documentation comments from class and protocol members is inherited by children. Set this option to disable the inheritance of the comments.
             """
     )
     

--- a/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
@@ -125,9 +125,8 @@ extension DocumentedArgument {
         flag: .init(preferred: "--skip-inherited-docs"),
         abstract: "Skip inherited docs from parent class or protocol members.",
         discussion: """
-            Documentation from class and protocol members is inherited by children. Set this
-            option to disable the inheritance.
-        """
+            Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
+            """
     )
     
 #if swift(>=5.9)

--- a/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
@@ -122,8 +122,8 @@ extension DocumentedArgument {
 
     /// Skip inherited docs from parent class or protocol members.
     static let skipInheritedDocs = Self(
-        option: .init(preferred: "--include-inherited-docs"),
-        abstract: "Include inherited docs from parent class or protocol members.",
+        flag: .init(preferred: "--skip-inherited-docs"),
+        abstract: "Skip inherited docs from parent class or protocol members.",
         discussion: """
             Documentation from class and protocol members is inherited by children. Set this
             option to disable the inheritance.

--- a/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -118,6 +118,16 @@ extension DocumentedArgument {
         discussion: """
             Supported access level values are: `open`, `public`, `internal`, `private`, `fileprivate`
             """
+    )
+
+    /// Skip inherited docs from parent class or protocol members.
+    static let skipInheritedDocs = Self(
+        option: .init(preferred: "--include-inherited-docs"),
+        abstract: "Include inherited docs from parent class or protocol members.",
+        discussion: """
+            Documentation from class and protocol members is inherited by children. Set this
+            option to disable the inheritance.
+        """
     )
     
 #if swift(>=5.9)

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -62,6 +62,11 @@ public enum HelpInformation {
             DocumentedArgument.skipSynthesizedSymbols,
             DocumentedArgument.minimumAccessLevel,
         ]
+
+#if swift(>=6.3)
+        supportedSymbolGraphFlags.append(DocumentedArgument.skipInheritedDocs)
+#endif
+
 #if swift(>=5.8)
         supportedSymbolGraphFlags.insert(DocumentedArgument.extendedTypes, at: 1)
 #else

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -63,7 +63,7 @@ public enum HelpInformation {
             DocumentedArgument.minimumAccessLevel,
         ]
 
-#if swift(>=6.3)
+#if compiler(>=6.3)
         supportedSymbolGraphFlags.append(DocumentedArgument.skipInheritedDocs)
 #endif
 

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -50,7 +50,7 @@ final class HelpInformationTests: XCTestCase {
                                       Include symbols with this access level or more.
                     Supported access level values are: `open`, `public`, `internal`, `private`, `fileprivate`
               --skip-inherited-docs   Skip inherited docs from parent class or protocol members.
-                    Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
+                    Documentation comments from class and protocol members is inherited by children. Set this option to disable the inheritance of the comments.
 
             DOCC INPUTS & OUTPUTS:
               <catalog-path>          Path to a '.docc' documentation catalog directory.

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -49,6 +49,8 @@ final class HelpInformationTests: XCTestCase {
               --symbol-graph-minimum-access-level
                                       Include symbols with this access level or more.
                     Supported access level values are: `open`, `public`, `internal`, `private`, `fileprivate`
+              --skip-inherited-docs   Skip inherited docs from parent class or protocol members.
+                    Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
 
             DOCC INPUTS & OUTPUTS:
               <catalog-path>          Path to a '.docc' documentation catalog directory.
@@ -196,6 +198,8 @@ final class HelpInformationTests: XCTestCase {
               --symbol-graph-minimum-access-level
                                       Include symbols with this access level or more.
                     Supported access level values are: `open`, `public`, `internal`, `private`, `fileprivate`
+              --skip-inherited-docs   Skip inherited docs from parent class or protocol members.
+                    Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
 
             DOCC PREVIEW OPTIONS:
               -p, --port <port-number>

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -199,7 +199,7 @@ final class HelpInformationTests: XCTestCase {
                                       Include symbols with this access level or more.
                     Supported access level values are: `open`, `public`, `internal`, `private`, `fileprivate`
               --skip-inherited-docs   Skip inherited docs from parent class or protocol members.
-                    Documentation from class and protocol members is inherited by children. Set this option to disable the inheritance.
+                    Documentation comments from class and protocol members is inherited by children. Set this option to disable the inheritance of the comments.
 
             DOCC PREVIEW OPTIONS:
               -p, --port <port-number>

--- a/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
@@ -451,6 +451,7 @@ final class ParsedArgumentsTests: XCTestCase {
             
             XCTAssertEqual(arguments.symbolGraphArguments.includeExtendedTypes, true)
             XCTAssertEqual(arguments.symbolGraphArguments.skipSynthesizedSymbols, true)
+            XCTAssertNil(arguments.symbolGraphArguments.skipInheritedDocs)
             XCTAssertEqual(arguments.symbolGraphArguments.minimumAccessLevel, "internal")
         }
         
@@ -459,6 +460,7 @@ final class ParsedArgumentsTests: XCTestCase {
             
             XCTAssertEqual(arguments.symbolGraphArguments.includeExtendedTypes, false)
             XCTAssertEqual(arguments.symbolGraphArguments.skipSynthesizedSymbols, true)
+            XCTAssertNil(arguments.symbolGraphArguments.skipInheritedDocs)
             XCTAssertNil(arguments.symbolGraphArguments.minimumAccessLevel)
         }
         
@@ -467,6 +469,7 @@ final class ParsedArgumentsTests: XCTestCase {
             
             XCTAssertEqual(arguments.symbolGraphArguments.includeExtendedTypes, false)
             XCTAssertEqual(arguments.symbolGraphArguments.skipSynthesizedSymbols, true)
+            XCTAssertNil(arguments.symbolGraphArguments.skipInheritedDocs)
             XCTAssertNil(arguments.symbolGraphArguments.minimumAccessLevel)
         }
         do {
@@ -474,6 +477,7 @@ final class ParsedArgumentsTests: XCTestCase {
             
             XCTAssertEqual(arguments.symbolGraphArguments.includeExtendedTypes, true)
             XCTAssertNil(arguments.symbolGraphArguments.skipSynthesizedSymbols)
+            XCTAssertNil(arguments.symbolGraphArguments.skipInheritedDocs)
             XCTAssertNil(arguments.symbolGraphArguments.minimumAccessLevel)
         }
     }
@@ -483,6 +487,7 @@ final class ParsedArgumentsTests: XCTestCase {
         
         XCTAssertNil(arguments.symbolGraphArguments.includeExtendedTypes)
         XCTAssertNil(arguments.symbolGraphArguments.skipSynthesizedSymbols)
+        XCTAssertNil(arguments.symbolGraphArguments.skipInheritedDocs)
         XCTAssertNil(arguments.symbolGraphArguments.minimumAccessLevel)
     }
 }


### PR DESCRIPTION
## Summary

There is a new symbol graph generation option from SwiftPM that controls whether inherited
docs should be included/skipped. Adopt this new option in the DocC plugin.

## Dependencies

This PR depends on a 6.3 toolchain that has the SwiftPM changes in it.

## Testing

Reviewers can use a nightly toolchain with the SwiftPM changes in it
and run one of the command plugins here to specify whether inherited docs should
be skipped or included.

Alternatively, a tester can use any older toolchain and get a warning if the option
is used since SwiftPM has no API for that in older versions.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
