### PR TITLE
Add .gitattributes for symlinks on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Symlinks type for Windows
+
+Plugins/Swift-DocC[[:space:]]Convert/Symbolic[[:space:]]Links/SharedPackagePluginExtensions symlink=dir
+Plugins/Swift-DocC[[:space:]]Convert/Symbolic[[:space:]]Links/SwiftDocCPluginUtilities symlink=dir
+Plugins/Swift-DocC[[:space:]]Preview/Symbolic[[:space:]]Links/SharedPackagePluginExtensions symlink=dir
+Plugins/Swift-DocC[[:space:]]Preview/Symbolic[[:space:]]Links/SwiftDocCPluginUtilities symlink=dir


### PR DESCRIPTION
There are edge cases during a checkout or clone where the symlink that is created on disk is not
the correct type.  In a failure case a file symlink is created with a source that is a directory.

This causes an invalid symlink so entities like swift package manager will fail to add the files in the directory to the dependency graph and fail compilation.

Adding a .gitattributes file with the symlink type works around this issue as on forces the link type instead of relying on heuristics.  Note: this will only affect checkouts/clones on Windows as the type is ignored for other platforms.

See: https://github.com/git-for-windows/git/issues/6089