### PR TITLE
Support snippets in files other than .swift

### DIFF
--- a/Sources/Snippets/Model/Snippet.swift
+++ b/Sources/Snippets/Model/Snippet.swift
@@ -30,8 +30,8 @@ public struct Snippet {
     public var slices: [String: Range<Int>]
 
     init(parsing source: String, sourceFile: URL) {
-        let commentStyle = SnippetLanguage.commentStyle(forFileExtension: sourceFile.pathExtension)
-        let extractor = SnippetParser(source: source, commentStyle: commentStyle)
+        let commentStyles = SnippetLanguage.commentStyles(forFileExtension: sourceFile.pathExtension)
+        let extractor = SnippetParser(source: source, commentStyles: commentStyles)
         self.explanation = extractor.explanationLines.joined(separator: "\n")
         self.presentationLines = extractor.presentationLines.map(String.init)
         self.slices = extractor.slices

--- a/Sources/Snippets/Model/Snippet.swift
+++ b/Sources/Snippets/Model/Snippet.swift
@@ -30,7 +30,8 @@ public struct Snippet {
     public var slices: [String: Range<Int>]
 
     init(parsing source: String, sourceFile: URL) {
-        let extractor = SnippetParser(source: source)
+        let commentStyle = SnippetLanguage.commentStyle(forFileExtension: sourceFile.pathExtension)
+        let extractor = SnippetParser(source: source, commentStyle: commentStyle)
         self.explanation = extractor.explanationLines.joined(separator: "\n")
         self.presentationLines = extractor.presentationLines.map(String.init)
         self.slices = extractor.slices

--- a/Sources/Snippets/Model/Snippet.swift
+++ b/Sources/Snippets/Model/Snippet.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A Swift code snippet.
+/// A code snippet.
 ///
 /// A *snippet* is a short, focused code example that can be shown with little to no context or prose.
 public struct Snippet {
@@ -37,7 +37,7 @@ public struct Snippet {
         self.sourceFile = sourceFile
     }
 
-    /// Create a Swift snippet by parsing a file.
+    /// Create a snippet by parsing a file.
     ///
     /// - Parameter sourceFile: The URL of the file to parse.
     public init(parsing sourceFile: URL) throws {

--- a/Sources/Snippets/Model/Snippet.swift
+++ b/Sources/Snippets/Model/Snippet.swift
@@ -29,12 +29,16 @@ public struct Snippet {
     /// Named line ranges in the snippet.
     public var slices: [String: Range<Int>]
 
+    /// Warnings generated during snippet parsing
+    public var warnings: [SnippetWarning]
+
     init(parsing source: String, sourceFile: URL) {
         let commentStyles = SnippetLanguage.commentStyles(forFileExtension: sourceFile.pathExtension)
-        let extractor = SnippetParser(source: source, commentStyles: commentStyles)
+        let extractor = SnippetParser(source: source, commentStyles: commentStyles, sourceFile: sourceFile.lastPathComponent)
         self.explanation = extractor.explanationLines.joined(separator: "\n")
         self.presentationLines = extractor.presentationLines.map(String.init)
         self.slices = extractor.slices
+        self.warnings = extractor.warnings
         self.sourceFile = sourceFile
     }
 

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -6,11 +6,30 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-/// A programming language supported for code snippets.
-///
-/// Only languages that use `//` line comments are currently supported,
-/// since ``SnippetParser`` uses `//` as the comment prefix for snippet
-/// markers and explanations.
+/// The comment syntax used by a language for snippet markers and explanations
+public enum CommentStyle: Sendable {
+    /// Line comment with a given prefix, e.g. `//` or `#`
+    case lineComment(String)
+    /// Block comment with a prefix and suffix, e.g. `<!--` and `-->`
+    case blockComment(prefix: String, suffix: String)
+
+    /// Inline comment style using `//`
+    public static var slashSlash: Self { 
+        .lineComment("//")
+    }
+    
+    /// Inline comment style using `#`
+    public static var hash: Self { 
+        .lineComment("#")
+    }
+
+    /// Default comment style for XML/HTML comments
+    public static var xml: Self {
+        .blockComment(prefix: "<!--", suffix: "-->")
+    }
+}
+
+/// A programming language supported for code snippets
 public enum SnippetLanguage: String, CaseIterable, Sendable {
     case swift
     case java
@@ -25,6 +44,11 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
     case typescript
     case scala
     case groovy
+    case python
+    case bash
+    case zsh
+    case xml
+    case html
 
     /// The language identifier used in symbol graphs and for syntax highlighting
     public var id: String {
@@ -39,9 +63,26 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
         case .go:         return "go"
         case .rust:       return "rust"
         case .javascript: return "javascript"
-        case .typescript:  return "typescript"
+        case .typescript: return "typescript"
         case .scala:      return "scala"
         case .groovy:     return "groovy"
+        case .python:     return "python"
+        case .bash:       return "bash"
+        case .zsh:        return "zsh"
+        case .html:       return "html"
+        case .xml:        return "xml"
+        }
+    }
+
+    /// The comment style used by this language
+    public var commentStyle: CommentStyle {
+        switch self {
+        case .python, .bash, .zsh:
+            return .hash
+        case .xml, .html:
+            return .xml
+        default:
+            return .slashSlash
         }
     }
 
@@ -61,6 +102,11 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
         case .typescript:  return ["ts", "tsx"]
         case .scala:       return ["scala"]
         case .groovy:      return ["groovy"]
+        case .python:      return ["py"]
+        case .bash:        return ["sh", "bash"]
+        case .zsh:         return ["zsh"]
+        case .html:        return ["html", "htm", "xhtml"]
+        case .xml:         return ["xml"]
         }
     }
 
@@ -76,5 +122,13 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
     public static func language(forFileExtension ext: String) -> SnippetLanguage? {
         let lowered = ext.lowercased()
         return allCases.first { $0.fileExtensions.contains(lowered) }
+    }
+
+    /// Look up the comment style for a given file extension
+    ///
+    /// Returns `.slashSlash` for unknown extensions, since most programming
+    /// languages use `//` line comments
+    public static func commentStyle(forFileExtension ext: String) -> CommentStyle {
+        language(forFileExtension: ext)?.commentStyle ?? .slashSlash
     }
 }

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -1,0 +1,80 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+/// A programming language supported for code snippets.
+///
+/// Only languages that use `//` line comments are currently supported,
+/// since ``SnippetParser`` uses `//` as the comment prefix for snippet
+/// markers and explanations.
+public enum SnippetLanguage: String, CaseIterable, Sendable {
+    case swift
+    case java
+    case kotlin
+    case c
+    case cpp
+    case objectiveC
+    case csharp
+    case go
+    case rust
+    case javascript
+    case typescript
+    case scala
+    case groovy
+
+    /// The language identifier used in symbol graphs and for syntax highlighting
+    public var id: String {
+        switch self {
+        case .swift:      return "swift"
+        case .java:       return "java"
+        case .kotlin:     return "kotlin"
+        case .c:          return "c"
+        case .cpp:        return "c++"
+        case .objectiveC: return "objective-c"
+        case .csharp:     return "csharp"
+        case .go:         return "go"
+        case .rust:       return "rust"
+        case .javascript: return "javascript"
+        case .typescript:  return "typescript"
+        case .scala:      return "scala"
+        case .groovy:     return "groovy"
+        }
+    }
+
+    /// The file extensions associated with this language
+    public var fileExtensions: [String] {
+        switch self {
+        case .swift:       return ["swift"]
+        case .java:        return ["java"]
+        case .kotlin:      return ["kt"]
+        case .c:           return ["c", "h"]
+        case .cpp:         return ["cpp", "hpp", "cc", "cxx"]
+        case .objectiveC:  return ["m", "mm"]
+        case .csharp:      return ["cs"]
+        case .go:          return ["go"]
+        case .rust:        return ["rs"]
+        case .javascript:  return ["js", "jsx"]
+        case .typescript:  return ["ts", "tsx"]
+        case .scala:       return ["scala"]
+        case .groovy:      return ["groovy"]
+        }
+    }
+
+    /// All file extensions supported for snippet extraction
+    public static var supportedFileExtensions: Set<String> {
+        Set(allCases.flatMap(\.fileExtensions))
+    }
+
+    /// Look up the language for a given file extension
+    ///
+    /// - Parameter ext: A file extension (without the leading dot), e.g. `"swift"`, `"java"`, `"cpp"`
+    /// - Returns: The matching language, or `nil` if the extension is not supported
+    public static func language(forFileExtension ext: String) -> SnippetLanguage? {
+        let lowered = ext.lowercased()
+        return allCases.first { $0.fileExtensions.contains(lowered) }
+    }
+}

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -27,6 +27,11 @@ public enum CommentStyle: Sendable {
     public static var xml: Self {
         .blockComment(prefix: "<!--", suffix: "-->")
     }
+
+    /// C-style block comment `/* ... */`
+    public static var cBlock: Self {
+        .blockComment(prefix: "/*", suffix: "*/")
+    }
 }
 
 /// A programming language supported for code snippets
@@ -74,15 +79,15 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
         }
     }
 
-    /// The comment style used by this language
-    public var commentStyle: CommentStyle {
+    /// The comment styles used by this language
+    public var commentStyles: [CommentStyle] {
         switch self {
         case .python, .bash, .zsh:
-            return .hash
+            return [.hash]
         case .xml, .html:
-            return .xml
+            return [.xml]
         default:
-            return .slashSlash
+            return [.slashSlash, .cBlock]
         }
     }
 
@@ -124,11 +129,11 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
         return allCases.first { $0.fileExtensions.contains(lowered) }
     }
 
-    /// Look up the comment style for a given file extension
+    /// Look up the comment styles for a given file extension
     ///
-    /// Returns `.slashSlash` for unknown extensions, since most programming
+    /// Returns `[.slashSlash]` for unknown extensions, since most programming
     /// languages use `//` line comments
-    public static func commentStyle(forFileExtension ext: String) -> CommentStyle {
-        language(forFileExtension: ext)?.commentStyle ?? .slashSlash
+    public static func commentStyles(forFileExtension ext: String) -> [CommentStyle] {
+        language(forFileExtension: ext)?.commentStyles ?? [.slashSlash]
     }
 }

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -12,9 +12,10 @@ public enum CommentStyle: Sendable {
     case lineComment(String)
     /// Block comment with a prefix and suffix, e.g. `<!--` and `-->`
     ///
-    /// Note: The snippet parser requires both the prefix and suffix to appear
-    /// on the same line. Multiline block comments are not supported for
-    /// snippet markers
+    /// Both single-line (e.g. `<!-- snippet.hide -->`) and multiline block
+    /// comments are supported as snippet markers. A multiline block comment
+    /// is recognized as a snippet marker only when the sole non-whitespace
+    /// content between the prefix and suffix is a valid snippet command
     case blockComment(prefix: String, suffix: String)
 
     /// Inline comment style using `//`

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,6 +11,10 @@ public enum CommentStyle: Sendable {
     /// Line comment with a given prefix, e.g. `//` or `#`
     case lineComment(String)
     /// Block comment with a prefix and suffix, e.g. `<!--` and `-->`
+    ///
+    /// Note: The snippet parser requires both the prefix and suffix to appear
+    /// on the same line. Multiline block comments are not supported for
+    /// snippet markers
     case blockComment(prefix: String, suffix: String)
 
     /// Inline comment style using `//`
@@ -40,8 +44,8 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
     case java
     case kotlin
     case c
-    case cpp
-    case objectiveC
+    case cpp = "c++"
+    case objectiveC = "objective-c"
     case csharp
     case go
     case rust
@@ -50,39 +54,23 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
     case scala
     case groovy
     case python
+    case ruby
     case bash
     case zsh
     case xml
     case html
+    case yaml
+    case toml
 
     /// The language identifier used in symbol graphs and for syntax highlighting
     public var id: String {
-        switch self {
-        case .swift:      return "swift"
-        case .java:       return "java"
-        case .kotlin:     return "kotlin"
-        case .c:          return "c"
-        case .cpp:        return "c++"
-        case .objectiveC: return "objective-c"
-        case .csharp:     return "csharp"
-        case .go:         return "go"
-        case .rust:       return "rust"
-        case .javascript: return "javascript"
-        case .typescript: return "typescript"
-        case .scala:      return "scala"
-        case .groovy:     return "groovy"
-        case .python:     return "python"
-        case .bash:       return "bash"
-        case .zsh:        return "zsh"
-        case .html:       return "html"
-        case .xml:        return "xml"
-        }
+        rawValue
     }
 
     /// The comment styles used by this language
     public var commentStyles: [CommentStyle] {
         switch self {
-        case .python, .bash, .zsh:
+        case .python, .bash, .zsh, .ruby, .yaml, .toml:
             return [.hash]
         case .xml, .html:
             return [.xml]
@@ -108,10 +96,13 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
         case .scala:       return ["scala"]
         case .groovy:      return ["groovy"]
         case .python:      return ["py"]
+        case .ruby:        return ["rb"]
         case .bash:        return ["sh", "bash"]
         case .zsh:         return ["zsh"]
         case .html:        return ["html", "htm", "xhtml"]
         case .xml:         return ["xml"]
+        case .yaml:        return ["yaml", "yml"]
+        case .toml:        return ["toml"]
         }
     }
 
@@ -131,9 +122,14 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
 
     /// Look up the comment styles for a given file extension
     ///
-    /// Returns `[.slashSlash]` for unknown extensions, since most programming
-    /// languages use `//` line comments
+    /// For unknown extensions, falls back to `//` line comments first,
+    /// then `#` line comments, covering the most common comment syntaxes
     public static func commentStyles(forFileExtension ext: String) -> [CommentStyle] {
-        language(forFileExtension: ext)?.commentStyles ?? [.slashSlash]
+        if let knownLanguage = language(forFileExtension: ext) {
+            knownLanguage.commentStyles
+        } else {
+            // wild guess, let's assume those are fine
+            [.slashSlash, .hash]
+        }
     }
 }

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -98,6 +98,33 @@ struct SnippetParser {
         slices[currentSlice.identifier] = currentSlice.startLine..<presentationLines.count
         self.currentSlice = nil
     }
+
+    /// Apply a parsed snippet marker result (hide/show/slice/end)
+    private mutating func applyMarkerResult(_ result: LineParseResult, lineNumber: inout Int) {
+        switch result {
+        case let .visibilityChange(isVisible):
+            self.isVisible = isVisible
+        case let .startSlice(identifier: identifier):
+            if self.isVisible {
+                startNewSlice(identifier: identifier, from: lineNumber)
+            }
+        case .endSlice:
+            endSlice()
+        case .presentationLine:
+            break
+        }
+    }
+
+    /// Append lines as presentation content, respecting visibility and leading-blank-line rules
+    private mutating func appendPresentationLines(_ lines: [Substring], lineNumber: inout Int) {
+        for line in lines {
+            if isVisible &&
+                !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace) {
+                presentationLines.append(line)
+                lineNumber += 1
+            }
+        }
+    }
     
     mutating func extractExplanation(from lines: inout ArraySlice<Substring>) {
         var explanationLines = [Substring]()
@@ -126,6 +153,55 @@ struct SnippetParser {
         self.explanationLines = explanationLines
     }
     
+    /// State for tracking a multiline block comment that might be a snippet marker
+    private struct PendingBlockComment {
+        var style: CommentStyle
+        var startIndex: Int           // source line index where the prefix appeared
+        var accumulatedContent: String // text after prefix, accumulated across lines
+        var accumulatedLines: [Substring] // raw lines consumed so far
+
+        /// Result of feeding a line into the pending block comment
+        enum AccumulateResult {
+            /// The block comment is still open, keep accumulating
+            case accumulating
+            /// The block comment closed and was a valid snippet marker
+            case snippetMarker(LineParseResult)
+            /// The block comment closed but was not a valid snippet marker;
+            /// the accumulated lines should be treated as presentation content
+            case notAMarker([Substring])
+        }
+
+        /// Feed a new line into this pending block comment
+        ///
+        /// Returns how the caller should proceed: keep accumulating,
+        /// apply a snippet marker, or emit the accumulated lines as content
+        mutating func accumulateBlockComment(line: Substring) -> AccumulateResult {
+            guard case .blockComment(_, let suffix) = style else {
+                fatalError("PendingBlockComment must have a blockComment style")
+            }
+            accumulatedLines.append(line)
+
+            guard let suffixRange = line.range(of: suffix) else {
+                // No closing suffix yet - keep accumulating
+                accumulatedContent += " " + line
+                return .accumulating
+            }
+
+            // Found closing suffix - extract content before it
+            let contentBeforeSuffix = line[line.startIndex..<suffixRange.lowerBound]
+            accumulatedContent += " " + contentBeforeSuffix
+
+            // Try to parse the accumulated content as a snippet marker
+            if let result = SnippetParser.tryParseAccumulatedBlockComment(
+                content: accumulatedContent,
+                style: style
+            ) {
+                return .snippetMarker(result)
+            }
+            return .notAMarker(accumulatedLines)
+        }
+    }
+
     init(source: String, commentStyles: [CommentStyle], sourceFile: String) {
         self.source = source
         self.commentStyles = commentStyles
@@ -135,9 +211,27 @@ struct SnippetParser {
         extractExplanation(from: &lines)
 
         var lineNumber = 0
+        var pendingBlockComment: PendingBlockComment? = nil
+
         for index in lines.indices {
             let line = lines[index]
             let sourceLineNumber = index + 1 // 1-based
+
+            // If we're accumulating a multiline block comment, feed this line in.
+            if var pending = pendingBlockComment {
+                switch pending.accumulateBlockComment(line: line) {
+                case .accumulating:
+                    pendingBlockComment = pending
+                case .snippetMarker(let result):
+                    applyMarkerResult(result, lineNumber: &lineNumber)
+                    pendingBlockComment = nil
+                case .notAMarker(let lines):
+                    appendPresentationLines(lines, lineNumber: &lineNumber)
+                    pendingBlockComment = nil
+                }
+                continue
+            }
+
             let result = SnippetParser.parseContent(from: line, commentStyles: commentStyles)
             switch result {
             case let .visibilityChange(isVisible):
@@ -149,9 +243,14 @@ struct SnippetParser {
             case .endSlice:
                 endSlice()
             case .presentationLine:
-                if isVisible &&
-                    // Don't include leading empty lines in the presentation content.
-                    !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace){
+                // Check if this line starts a multiline block comment
+                if let pending = SnippetParser.tryStartMultilineBlockComment(
+                    from: line, at: index, commentStyles: commentStyles
+                ) {
+                    pendingBlockComment = pending
+                } else if isVisible &&
+                    // Don't include leading empty lines in the presentation content
+                    !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace) {
                     presentationLines.append(line)
                     lineNumber += 1
                 }
@@ -170,6 +269,11 @@ struct SnippetParser {
                     ))
                 }
             }
+        }
+
+        // If we ended with an unclosed block comment, emit the accumulated lines as presentation
+        if let pending = pendingBlockComment {
+            appendPresentationLines(pending.accumulatedLines, lineNumber: &lineNumber)
         }
         
         endSlice()
@@ -307,6 +411,74 @@ extension SnippetParser {
             return marker
         }
         return .presentationLine
+    }
+
+    // ==== -----------------------------------------------------------------------
+    // MARK: Multiline block comment support
+
+    /// Check if a line opens a block comment without closing it on the same line
+    ///
+    /// Returns a `PendingBlockComment` if this line contains a block comment
+    /// prefix (e.g. `<!--`) but no matching suffix, indicating the start of a
+    /// multiline block comment that might be a snippet marker
+    private static func tryStartMultilineBlockComment(
+        from line: Substring,
+        at index: Int,
+        commentStyles: [CommentStyle]
+    ) -> PendingBlockComment? {
+        for style in commentStyles {
+            guard case .blockComment(let prefix, let suffix) = style else {
+                continue
+            }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix(prefix) else {
+                continue
+            }
+            // If the suffix is also present, this is a single-line block comment (already handled)
+            guard trimmed.range(of: suffix) == nil else {
+                continue
+            }
+            // Started a block comment without closing - begin accumulation
+            let contentAfterPrefix = trimmed.dropFirst(prefix.count)
+            return PendingBlockComment(
+                style: style,
+                startIndex: index,
+                accumulatedContent: String(contentAfterPrefix),
+                accumulatedLines: [line]
+            )
+        }
+        return nil
+    }
+
+    /// Try to parse accumulated multiline block comment content as a snippet marker
+    ///
+    /// The content must contain only whitespace and a valid snippet command
+    /// (e.g. `snippet.hide`) - any additional non-whitespace text means this
+    /// is a regular comment, not a snippet marker
+    private static func tryParseAccumulatedBlockComment(
+        content: String,
+        style: CommentStyle
+    ) -> LineParseResult? {
+        guard case .blockComment(let prefix, let suffix) = style else {
+            return nil
+        }
+        // The accumulated content should be only whitespace + one snippet command
+        // Verify there's no extra text beyond the snippet marker
+        let trimmed = content.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        // Check that the entire trimmed content is just "snippet.<command>" with no extra words
+        let words = trimmed.split(whereSeparator: { $0.isWhitespace })
+        guard words.count == 1 else {
+            // Multiple non-whitespace tokens -> not a pure snippet marker, just a normal comment
+            return nil
+        }
+
+        // Build a synthetic single-line block comment for parsing
+        let synthetic: Substring = Substring("\(prefix) \(trimmed) \(suffix)")
+        return tryParseSnippetMarker(from: synthetic, commentStyle: style)
     }
 
     /// Check if a line has non-whitespace content after a block comment

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -72,7 +72,7 @@ extension Substring {
 /// Extracts a ``Snippet`` structure from source code
 struct SnippetParser {
     var source: String
-    var commentStyle: CommentStyle
+    var commentStyles: [CommentStyle]
     var explanationLines = [Substring]()
     var presentationLines = [Substring]()
     var slices = [String: Range<Int>]()
@@ -102,10 +102,10 @@ struct SnippetParser {
         var explanationLines = [Substring]()
         for var line in lines {
             guard !line.isEmptyOrWhiteSpace,
-                  SnippetParser.tryParseSnippetMarker(from: line, commentStyle: commentStyle) == nil else {
+                  SnippetParser.tryParseSnippetMarker(from: line, commentStyles: commentStyles) == nil else {
                 break
             }
-            guard SnippetParser.tryParseCommentMarkerPrefix(from: &line, commentStyle: commentStyle) else {
+            guard SnippetParser.tryParseCommentMarkerPrefix(from: &line, commentStyles: commentStyles) else {
                 break
             }
             explanationLines.append(line)
@@ -125,9 +125,9 @@ struct SnippetParser {
         self.explanationLines = explanationLines
     }
     
-    init(source: String, commentStyle: CommentStyle) {
+    init(source: String, commentStyles: [CommentStyle]) {
         self.source = source
-        self.commentStyle = commentStyle
+        self.commentStyles = commentStyles
         var lines = source.split(separator: "\n", omittingEmptySubsequences: false)[...]
             .drop { $0.isEmptyOrWhiteSpace }
 
@@ -135,7 +135,7 @@ struct SnippetParser {
 
         var lineNumber = 0
         for line in lines {
-            switch SnippetParser.parseContent(from: line, commentStyle: commentStyle) {
+            switch SnippetParser.parseContent(from: line, commentStyles: commentStyles) {
             case let .visibilityChange(isVisible):
                 self.isVisible = isVisible
             case let .startSlice(identifier: identifier):
@@ -242,6 +242,45 @@ extension SnippetParser {
         commentStyle: CommentStyle
     ) -> LineParseResult {
         if let marker = tryParseSnippetMarker(from: line, commentStyle: commentStyle) {
+            return marker
+        }
+        return .presentationLine
+    }
+
+    // ==== -----------------------------------------------------------------------
+    // MARK: Multi-style overloads
+
+    static func tryParseSnippetMarker(
+        from line: Substring,
+        commentStyles: [CommentStyle]
+    ) -> LineParseResult? {
+        for style in commentStyles {
+            if let result = tryParseSnippetMarker(from: line, commentStyle: style) {
+                return result
+            }
+        }
+        return nil
+    }
+
+    static func tryParseCommentMarkerPrefix(
+        from line: inout Substring,
+        commentStyles: [CommentStyle]
+    ) -> Bool {
+        for style in commentStyles {
+            var candidate = line
+            if tryParseCommentMarkerPrefix(from: &candidate, commentStyle: style) {
+                line = candidate
+                return true
+            }
+        }
+        return false
+    }
+
+    static func parseContent(
+        from line: Substring,
+        commentStyles: [CommentStyle]
+    ) -> LineParseResult {
+        if let marker = tryParseSnippetMarker(from: line, commentStyles: commentStyles) {
             return marker
         }
         return .presentationLine

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -228,6 +228,11 @@ extension SnippetParser {
             guard trimmed.trimExpectedPrefix(prefix) else { return false }
             if let closingRange = trimmed.range(of: suffix, options: .backwards) {
                 trimmed = trimmed[..<closingRange.lowerBound]
+                // Note: This trims trailing whitespace inside the block comment,
+                // which is correct for snippet markers (e.g. `/* snippet.hide */`).
+                // If there were code after the suffix (e.g. `/* snippet.hide */ code`),
+                // the trailing whitespace trimmed here would be the wrong whitespace,
+                // but that's not a realistic scenario for snippet markers
                 while trimmed.last?.isWhitespace == true {
                     trimmed = trimmed.dropLast()
                 }

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -64,7 +64,7 @@ extension Substring {
             }
             removeFirst(lowercasePrefix.count)
         }
-        
+
         return true
     }
 }
@@ -77,6 +77,7 @@ struct SnippetParser {
     var presentationLines = [Substring]()
     var slices = [String: Range<Int>]()
     var currentSlice: (identifier: String, startLine: Int)? = nil
+    var warnings = [SnippetWarning]()
     private var isVisible = true
     
     mutating func startNewSlice(identifier: String, from lineNumber: Int) {
@@ -125,7 +126,7 @@ struct SnippetParser {
         self.explanationLines = explanationLines
     }
     
-    init(source: String, commentStyles: [CommentStyle]) {
+    init(source: String, commentStyles: [CommentStyle], sourceFile: String) {
         self.source = source
         self.commentStyles = commentStyles
         var lines = source.split(separator: "\n", omittingEmptySubsequences: false)[...]
@@ -134,8 +135,11 @@ struct SnippetParser {
         extractExplanation(from: &lines)
 
         var lineNumber = 0
-        for line in lines {
-            switch SnippetParser.parseContent(from: line, commentStyles: commentStyles) {
+        for index in lines.indices {
+            let line = lines[index]
+            let sourceLineNumber = index + 1 // 1-based
+            let result = SnippetParser.parseContent(from: line, commentStyles: commentStyles)
+            switch result {
             case let .visibilityChange(isVisible):
                 self.isVisible = isVisible
             case let .startSlice(identifier: identifier):
@@ -150,6 +154,20 @@ struct SnippetParser {
                     !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace){
                     presentationLines.append(line)
                     lineNumber += 1
+                }
+            }
+
+            // Warn about content after a block comment snippet marker that would be silently dropped
+            if case .presentationLine = result {} else {
+                if let trailing = SnippetParser.trailingContentAfterBlockCommentMarker(
+                    in: line, commentStyles: commentStyles
+                ) {
+                    warnings.append(SnippetWarning(
+                        file: sourceFile,
+                        line: sourceLineNumber,
+                        warning: "content after block comment snippet marker will be ignored",
+                        text: String(trailing)
+                    ))
                 }
             }
         }
@@ -199,7 +217,7 @@ extension SnippetParser {
         guard line.trimExpectedPrefix("snippet.", considerCase: false) else {
             return nil
         }
-        
+
         if line.trimExpectedPrefix("show", considerCase: false) {
             return .visibilityChange(isVisible: true)
         } else if line.trimExpectedPrefix("hide", considerCase: false) {
@@ -289,5 +307,46 @@ extension SnippetParser {
             return marker
         }
         return .presentationLine
+    }
+
+    /// Check if a line has non-whitespace content after a block comment
+    /// snippet marker suffix (e.g. `/* snippet.hide */ let x = 1`)
+    ///
+    /// Returns the trailing content if found, or `nil` if the line is clean
+    static func trailingContentAfterBlockCommentMarker(
+        in line: Substring,
+        commentStyles: [CommentStyle]
+    ) -> Substring? {
+        for style in commentStyles {
+            guard case .blockComment(let prefix, let suffix) = style else {
+                continue
+            }
+            let trimmed = line.drop { $0.isWhitespace }
+            guard trimmed.hasPrefix(prefix),
+                  let suffixRange = trimmed.range(of: suffix, options: .backwards) else {
+                continue
+            }
+            let afterSuffix = trimmed[suffixRange.upperBound...]
+            if !afterSuffix.allSatisfy(\.isWhitespace) {
+                return afterSuffix.drop { $0.isWhitespace }
+            }
+        }
+        return nil
+    }
+}
+
+/// A warning emitted during snippet parsing
+public struct SnippetWarning: Sendable {
+    /// The source file that triggered the warning
+    public var file: String
+    /// The 1-based line number in the source file
+    public var line: Int
+    /// A short description of the issue
+    public var warning: String
+    /// The source text that caused the warning
+    public var text: String
+
+    public var description: String {
+        "\(file):\(line): warning: \(warning): \(text)"
     }
 }

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -69,12 +69,10 @@ extension Substring {
     }
 }
 
-/// Extracts a ``Snippet`` structure from Swift source code.
-///
-/// - todo: In order to support different styles of comments, it might be
-///   better to adopt SwiftSyntax if possible in the future.
+/// Extracts a ``Snippet`` structure from source code
 struct SnippetParser {
     var source: String
+    var commentStyle: CommentStyle
     var explanationLines = [Substring]()
     var presentationLines = [Substring]()
     var slices = [String: Range<Int>]()
@@ -104,10 +102,10 @@ struct SnippetParser {
         var explanationLines = [Substring]()
         for var line in lines {
             guard !line.isEmptyOrWhiteSpace,
-                  SnippetParser.tryParseSnippetMarker(from: line) == nil else {
+                  SnippetParser.tryParseSnippetMarker(from: line, commentStyle: commentStyle) == nil else {
                 break
             }
-            guard SnippetParser.tryParseCommentMarkerPrefix(from: &line) else {
+            guard SnippetParser.tryParseCommentMarkerPrefix(from: &line, commentStyle: commentStyle) else {
                 break
             }
             explanationLines.append(line)
@@ -127,16 +125,17 @@ struct SnippetParser {
         self.explanationLines = explanationLines
     }
     
-    init(source: String) {
+    init(source: String, commentStyle: CommentStyle) {
         self.source = source
+        self.commentStyle = commentStyle
         var lines = source.split(separator: "\n", omittingEmptySubsequences: false)[...]
             .drop { $0.isEmptyOrWhiteSpace }
-        
+
         extractExplanation(from: &lines)
-                
+
         var lineNumber = 0
         for line in lines {
-            switch SnippetParser.parseContent(from: line) {
+            switch SnippetParser.parseContent(from: line, commentStyle: commentStyle) {
             case let .visibilityChange(isVisible):
                 self.isVisible = isVisible
             case let .startSlice(identifier: identifier):
@@ -186,9 +185,12 @@ extension SnippetParser {
         case presentationLine
     }
     
-    static func tryParseSnippetMarker(from line: Substring) -> LineParseResult? {
+    static func tryParseSnippetMarker(
+        from line: Substring,
+        commentStyle: CommentStyle
+    ) -> LineParseResult? {
         var line = line
-        guard SnippetParser.tryParseCommentMarkerPrefix(from: &line) else {
+        guard SnippetParser.tryParseCommentMarkerPrefix(from: &line, commentStyle: commentStyle) else {
             return nil
         }
         
@@ -214,17 +216,32 @@ extension SnippetParser {
         }
     }
     
-    static func tryParseCommentMarkerPrefix(from line: inout Substring) -> Bool {
+    static func tryParseCommentMarkerPrefix(
+        from line: inout Substring,
+        commentStyle: CommentStyle
+    ) -> Bool {
         var trimmed = line.drop { $0.isWhitespace }
-        guard trimmed.trimExpectedPrefix("//") else {
-            return false
+        switch commentStyle {
+        case .lineComment(let prefix):
+            guard trimmed.trimExpectedPrefix(prefix) else { return false }
+        case .blockComment(let prefix, let suffix):
+            guard trimmed.trimExpectedPrefix(prefix) else { return false }
+            if let closingRange = trimmed.range(of: suffix, options: .backwards) {
+                trimmed = trimmed[..<closingRange.lowerBound]
+                while trimmed.last?.isWhitespace == true {
+                    trimmed = trimmed.dropLast()
+                }
+            }
         }
         line = trimmed
         return true
     }
     
-    static func parseContent(from line: Substring) -> LineParseResult {
-        if let marker = tryParseSnippetMarker(from: line) {
+    static func parseContent(
+        from line: Substring,
+        commentStyle: CommentStyle
+    ) -> LineParseResult {
+        if let marker = tryParseSnippetMarker(from: line, commentStyle: commentStyle) {
             return marker
         }
         return .presentationLine

--- a/Sources/SwiftDocCPluginUtilities/Snippets/SnippetExtractor.swift
+++ b/Sources/SwiftDocCPluginUtilities/Snippets/SnippetExtractor.swift
@@ -66,7 +66,7 @@ public class SnippetExtractor {
         return FileManager.default.fileExists(atPath: path)
     }
 
-    /// Returns all of the `.swift` files under a directory recursively.
+    /// Returns all snippet files under a directory recursively.
     ///
     /// Provided for testing.
     var _findSnippetFilesInDirectory: (_ directory: URL) -> [String] = { directory -> [String] in
@@ -78,7 +78,7 @@ public class SnippetExtractor {
         }
         var snippetInputFiles = [String]()
         for case let potentialSnippetURL as URL in snippetEnumerator {
-            guard potentialSnippetURL.pathExtension.lowercased() == "swift" else {
+            guard !potentialSnippetURL.pathExtension.isEmpty else {
                 continue
             }
             snippetInputFiles.append(potentialSnippetURL.path)

--- a/Sources/snippet-extract/SnippetBuildCommand.swift
+++ b/Sources/snippet-extract/SnippetBuildCommand.swift
@@ -152,11 +152,7 @@ struct SnippetExtractCommand {
     }
 
     func printWarning(_ message: String) {
-        guard let msg = "\(message)\n".data(using: .utf8) else {
-            return 
-        }
-        
-        FileHandle.standardError.write(msg)
+        FileHandle.standardError.write(Data(message.utf8))
     }
 }
 

--- a/Sources/snippet-extract/SnippetBuildCommand.swift
+++ b/Sources/snippet-extract/SnippetBuildCommand.swift
@@ -91,6 +91,11 @@ struct SnippetExtractCommand {
         let snippets = try snippetFiles.map {
             try Snippet(parsing: URL(fileURLWithPath: $0))
         }
+        for snippet in snippets {
+            for warning in snippet.warnings {
+                printWarning(warning.description)
+            }
+        }
         guard snippets.count > 0 else { return }
         let symbolGraphFilename = URL(fileURLWithPath: outputFile)
         try emitSymbolGraph(for: snippets, to: symbolGraphFilename, moduleName: moduleName)
@@ -144,6 +149,14 @@ struct SnippetExtractCommand {
             printUsage()
             throw error
         }
+    }
+
+    func printWarning(_ message: String) {
+        guard let msg = "\(message)\n".data(using: .utf8) else {
+            return 
+        }
+        
+        FileHandle.standardError.write(msg)
     }
 }
 

--- a/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
+++ b/Sources/snippet-extract/Utility/SymbolGraph+Snippet.swift
@@ -18,9 +18,11 @@ extension SymbolGraph.Symbol {
     ///   - moduleName: The name to use for the package name in the snippet symbol's precise identifier.
     public init(_ snippet: Snippets.Snippet, moduleName: String) throws {
         let basename = snippet.sourceFile.deletingPathExtension().lastPathComponent
-        let identifier = SymbolGraph.Symbol.Identifier(precise: "$snippet__\(moduleName).\(basename)", interfaceLanguage: "swift")
+        let language = SnippetLanguage.language(forFileExtension: snippet.sourceFile.pathExtension)?.id
+            ?? snippet.sourceFile.pathExtension.lowercased()
+        let identifier = SymbolGraph.Symbol.Identifier(precise: "$snippet__\(moduleName).\(basename)", interfaceLanguage: language)
         let names = SymbolGraph.Symbol.Names.init(title: basename, navigator: nil, subHeading: nil, prose: nil)
-        
+
         var pathComponents = Array(snippet.sourceFile.absoluteURL.deletingPathExtension().pathComponents[...])
 
         guard let snippetsPathComponentIndex = pathComponents.firstIndex(where: {
@@ -50,7 +52,7 @@ extension SymbolGraph.Symbol {
                   accessLevel: accessLevel,
                   kind: kind,
                   mixins: [
-                      SymbolGraph.Symbol.Snippet.mixinKey: SymbolGraph.Symbol.Snippet(language: "swift", lines: snippet.presentationLines, slices: snippet.slices)
+                      SymbolGraph.Symbol.Snippet.mixinKey: SymbolGraph.Symbol.Snippet(language: language, lines: snippet.presentationLines, slices: snippet.slices)
                   ],
                   isVirtual: true)
     }

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -530,35 +530,168 @@ class SnippetParseTests: XCTestCase {
         }
         """, snippet.presentationCode)
     }
+
+    func testParsePythonSnippet() {
+        let pythonSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.py")
+
+        let source = """
+        # A Python example showing list comprehension
+
+        # snippet.hide
+        import sys
+        # snippet.show
+
+        # snippet.setup
+        numbers = [1, 2, 3, 4, 5]
+        # snippet.end
+
+        squares = [x * x for x in numbers]
+        print(squares)
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: pythonSourceFile)
+        XCTAssertEqual("A Python example showing list comprehension", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["setup"], "numbers = [1, 2, 3, 4, 5]")
+
+        let expectedCode = """
+        numbers = [1, 2, 3, 4, 5]
+
+        squares = [x * x for x in numbers]
+        print(squares)
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    func testParseBashSnippet() {
+        let bashSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.sh")
+
+        let source = """
+        # A bash script example
+
+        # snippet.hide
+        set -euo pipefail
+        # snippet.show
+
+        echo "Hello, world!"
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: bashSourceFile)
+        XCTAssertEqual("A bash script example", snippet.explanation)
+        XCTAssertEqual("echo \"Hello, world!\"", snippet.presentationCode)
+    }
+
+    func testParseHtmlSnippet() {
+        let htmlSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!-- snippet.hide -->
+        <!DOCTYPE html>
+        <!-- snippet.show -->
+
+        <!-- snippet.body -->
+        <div class="container">
+            <p>Hello</p>
+        </div>
+        <!-- snippet.end -->
+
+        <footer>End</footer>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["body"], """
+        <div class="container">
+            <p>Hello</p>
+        </div>
+        """)
+
+        let expectedCode = """
+        <div class="container">
+            <p>Hello</p>
+        </div>
+
+        <footer>End</footer>
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
 }
 
 class SnippetParseMarkerTests: XCTestCase {
     func testParseHideShow() {
-        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// snippet.show"))
-        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// Snippet.Show"))
-        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// SNIPPET.SHOW"))
-        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "//      snippet.show"))
-        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "//      snippet.show      "))
+        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// snippet.show", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// Snippet.Show", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// SNIPPET.SHOW", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "//      snippet.show", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "//      snippet.show      ", commentStyle: .slashSlash))
 
-        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// snippet.hide"))
-        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// Snippet.Hide"))
-        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// SNIPPET.HIDE"))
-        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "//      snippet.hide"))
-        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "//      snippet.hide   "))
+        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// snippet.hide", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// Snippet.Hide", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "// SNIPPET.HIDE", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "//      snippet.hide", commentStyle: .slashSlash))
+        XCTAssertEqual(.visibilityChange(isVisible: false), SnippetParser.tryParseSnippetMarker(from: "//      snippet.hide   ", commentStyle: .slashSlash))
 
         // Markers need to be a comment.
-        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.show"))
-        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.hide"))
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.show", commentStyle: .slashSlash))
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.hide", commentStyle: .slashSlash))
     }
-    
+
     func testParseSliceStartAndEnd() {
-        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "// snippet.foo"))
-        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "//   snippet.foo"))
-        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "//   snippet.foo    "))
-        
-        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "// snippet.end"))
-        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "// snippet.END"))
-        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "//   snippet.end"))
-        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "//    snippet.end  "))
+        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "// snippet.foo", commentStyle: .slashSlash))
+        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "//   snippet.foo", commentStyle: .slashSlash))
+        XCTAssertEqual(.startSlice(identifier: "foo"), SnippetParser.tryParseSnippetMarker(from: "//   snippet.foo    ", commentStyle: .slashSlash))
+
+        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "// snippet.end", commentStyle: .slashSlash))
+        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "// snippet.END", commentStyle: .slashSlash))
+        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "//   snippet.end", commentStyle: .slashSlash))
+        XCTAssertEqual(.endSlice, SnippetParser.tryParseSnippetMarker(from: "//    snippet.end  ", commentStyle: .slashSlash))
+    }
+
+    func testParseHashCommentMarkers() {
+        XCTAssertEqual(.visibilityChange(isVisible: true),
+                       SnippetParser.tryParseSnippetMarker(from: "# snippet.show", commentStyle: .hash))
+        XCTAssertEqual(.visibilityChange(isVisible: false),
+                       SnippetParser.tryParseSnippetMarker(from: "# snippet.hide", commentStyle: .hash))
+        XCTAssertEqual(.visibilityChange(isVisible: true),
+                       SnippetParser.tryParseSnippetMarker(from: "#   snippet.show", commentStyle: .hash))
+        XCTAssertEqual(.startSlice(identifier: "foo"),
+                       SnippetParser.tryParseSnippetMarker(from: "# snippet.foo", commentStyle: .hash))
+        XCTAssertEqual(.endSlice,
+                       SnippetParser.tryParseSnippetMarker(from: "# snippet.end", commentStyle: .hash))
+
+        // Hash markers need to be a comment
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.show", commentStyle: .hash))
+
+        // Hash style should NOT match // comments
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "// snippet.show", commentStyle: .hash))
+    }
+
+    func testParseHtmlCommentMarkers() {
+        XCTAssertEqual(.visibilityChange(isVisible: true),
+                       SnippetParser.tryParseSnippetMarker(from: "<!-- snippet.show -->", commentStyle: .xml))
+        XCTAssertEqual(.visibilityChange(isVisible: false),
+                       SnippetParser.tryParseSnippetMarker(from: "<!-- snippet.hide -->", commentStyle: .xml))
+        XCTAssertEqual(.visibilityChange(isVisible: true),
+                       SnippetParser.tryParseSnippetMarker(from: "<!--   snippet.show   -->", commentStyle: .xml))
+        XCTAssertEqual(.startSlice(identifier: "foo"),
+                       SnippetParser.tryParseSnippetMarker(from: "<!-- snippet.foo -->", commentStyle: .xml))
+        XCTAssertEqual(.endSlice,
+                       SnippetParser.tryParseSnippetMarker(from: "<!-- snippet.end -->", commentStyle: .xml))
+
+        // HTML markers without closing --> should still work
+        XCTAssertEqual(.visibilityChange(isVisible: true),
+                       SnippetParser.tryParseSnippetMarker(from: "<!-- snippet.show", commentStyle: .xml))
+
+        // HTML markers need to be a comment
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "snippet.show", commentStyle: .xml))
+
+        // HTML style should NOT match // comments
+        XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "// snippet.show", commentStyle: .xml))
     }
 }

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -461,15 +461,74 @@ class SnippetParseTests: XCTestCase {
             // snippet.end
             func bar() {}
             """
-            
+
             let expectedPresentationCode = """
             func bar() {}
             """
-            
+
             let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
             XCTAssertEqual(expectedPresentationCode, snippet.presentationCode)
             XCTAssertTrue(snippet.slices.isEmpty)
         }
+    }
+
+    func testParseJavaSnippet() {
+        let javaSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("JavaExample.java")
+
+        let source = """
+        // A Java example showing basic usage.
+
+        // snippet.hide
+        import java.util.List;
+        // snippet.show
+
+        // snippet.setup
+        List<String> items = List.of("a", "b", "c");
+        // snippet.end
+
+        for (String item : items) {
+            System.out.println(item);
+        }
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: javaSourceFile)
+        XCTAssertEqual("A Java example showing basic usage.", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["setup"], "List<String> items = List.of(\"a\", \"b\", \"c\");")
+
+        let expectedCode = """
+        List<String> items = List.of("a", "b", "c");
+
+        for (String item : items) {
+            System.out.println(item);
+        }
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    func testParseCppSnippet() {
+        let source = """
+        // A C++ snippet
+
+        // snippet.hide
+        #include <iostream>
+        // snippet.show
+
+        int main() {
+            std::cout << "Hello" << std::endl;
+            return 0;
+        }
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual("A C++ snippet", snippet.explanation)
+        XCTAssertEqual("""
+        int main() {
+            std::cout << "Hello" << std::endl;
+            return 0;
+        }
+        """, snippet.presentationCode)
     }
 }
 

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -746,6 +746,68 @@ class SnippetParseTests: XCTestCase {
     }
 }
 
+class SnippetParseWarningTests: XCTestCase {
+    static let fakeSnippetsDir = URL(fileURLWithPath: "/tmp/MyPackage/Snippets")
+
+    func testWarningOnTrailingContentAfterBlockCommentMarker() {
+        let javaSourceFile = SnippetParseWarningTests.fakeSnippetsDir
+            .appendingPathComponent("Example.java")
+
+        let source = """
+        // An example
+
+        /* snippet.hide */ import java.util.List;
+        // snippet.show
+
+        List<String> items = List.of("a", "b");
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: javaSourceFile)
+        XCTAssertEqual(1, snippet.warnings.count)
+        let warning = snippet.warnings[0]
+        XCTAssertEqual("Example.java", warning.file)
+        XCTAssertEqual(3, warning.line)
+        XCTAssertEqual("import java.util.List;", warning.text)
+        XCTAssertTrue(warning.description.contains("Example.java:3:"))
+    }
+
+    func testNoWarningOnCleanBlockCommentMarker() {
+        let javaSourceFile = SnippetParseWarningTests.fakeSnippetsDir
+            .appendingPathComponent("Example.java")
+
+        let source = """
+        // An example
+
+        /* snippet.hide */
+        import java.util.List;
+        // snippet.show
+
+        List<String> items = List.of("a", "b");
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: javaSourceFile)
+        XCTAssertTrue(snippet.warnings.isEmpty)
+    }
+
+    func testNoWarningOnLineCommentMarkers() {
+        let swiftSourceFile = SnippetParseWarningTests.fakeSnippetsDir
+            .appendingPathComponent("Example.swift")
+
+        let source = """
+        // An example
+
+        // snippet.hide
+        import Foundation
+        // snippet.show
+
+        print("hello")
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: swiftSourceFile)
+        XCTAssertTrue(snippet.warnings.isEmpty)
+    }
+}
+
 class SnippetParseMarkerTests: XCTestCase {
     func testParseHideShow() {
         XCTAssertEqual(.visibilityChange(isVisible: true), SnippetParser.tryParseSnippetMarker(from: "// snippet.show", commentStyle: .slashSlash))

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -624,6 +624,126 @@ class SnippetParseTests: XCTestCase {
         """
         XCTAssertEqual(expectedCode, snippet.presentationCode)
     }
+
+    func testParseYamlSnippet() {
+        let yamlSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.yaml")
+
+        let source = """
+        # A YAML configuration example
+
+        # snippet.hide
+        version: "3"
+        # snippet.show
+
+        # snippet.services
+        services:
+          web:
+            image: nginx
+            ports:
+              - "80:80"
+        # snippet.end
+
+        volumes:
+          data: {}
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: yamlSourceFile)
+        XCTAssertEqual("A YAML configuration example", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["services"], """
+        services:
+          web:
+            image: nginx
+            ports:
+              - "80:80"
+        """)
+
+        let expectedCode = """
+        services:
+          web:
+            image: nginx
+            ports:
+              - "80:80"
+
+        volumes:
+          data: {}
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    func testParseUnknownLanguageWithSlashSlashComments() {
+        let pklSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.pkl")
+
+        // We just assume an unknown language can likely handle # or //
+        let source = """
+        // A Pkl configuration example
+
+        // snippet.hide
+        amends "base.pkl"
+        // snippet.show
+
+        # snippet.config
+        host = "localhost"
+        port = 8080
+        # snippet.end
+
+        debug = true
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: pklSourceFile)
+        XCTAssertEqual("A Pkl configuration example", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["config"], """
+        host = "localhost"
+        port = 8080
+        """)
+
+        let expectedCode = """
+        host = "localhost"
+        port = 8080
+
+        debug = true
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    func testParseUnknownLanguageWithHashComments() {
+        let confSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.conf")
+
+        let source = """
+        # A configuration file example
+
+        # snippet.hide
+        [defaults]
+        # snippet.show
+
+        # snippet.main
+        server = 127.0.0.1
+        port = 3000
+        # snippet.end
+
+        log_level = info
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: confSourceFile)
+        XCTAssertEqual("A configuration file example", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["main"], """
+        server = 127.0.0.1
+        port = 3000
+        """)
+
+        let expectedCode = """
+        server = 127.0.0.1
+        port = 3000
+
+        log_level = info
+        """
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
 }
 
 class SnippetParseMarkerTests: XCTestCase {

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -880,3 +880,197 @@ class SnippetParseMarkerTests: XCTestCase {
         XCTAssertNil(SnippetParser.tryParseSnippetMarker(from: "// snippet.show", commentStyle: .xml))
     }
 }
+
+// MARK: Multiline Block Comment Tests
+
+class SnippetParseMultilineBlockCommentTests: XCTestCase {
+    static let fakeSnippetsDir = URL(fileURLWithPath: "/tmp/MyPackage/Snippets")
+
+    func testParseMultilineBlockCommentHide() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!--
+          snippet.hide
+        -->
+        <!DOCTYPE html>
+        <!-- snippet.show -->
+
+        <p>Hello</p>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        XCTAssertEqual("<p>Hello</p>", snippet.presentationCode)
+    }
+
+    func testParseMultilineBlockCommentWithSuffixOnMarkerLine() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!--
+          snippet.hide -->
+        <!DOCTYPE html>
+        <!-- snippet.show -->
+
+        <p>Hello</p>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        XCTAssertEqual("<p>Hello</p>", snippet.presentationCode)
+    }
+
+    func testParseMultilineBlockCommentWithPrefixOnMarkerLine() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!-- snippet.hide
+        -->
+        <!DOCTYPE html>
+        <!-- snippet.show -->
+
+        <p>Hello</p>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        XCTAssertEqual("<p>Hello</p>", snippet.presentationCode)
+    }
+
+    func testParseMultilineCBlockComment() {
+        let javaSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.java")
+
+        let source = """
+        // A Java example
+
+        /*
+          snippet.hide
+        */
+        import java.util.List;
+        // snippet.show
+
+        List<String> items = List.of("a", "b");
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: javaSourceFile)
+        XCTAssertEqual("A Java example", snippet.explanation)
+        XCTAssertEqual("List<String> items = List.of(\"a\", \"b\");", snippet.presentationCode)
+    }
+
+    func testParseMultilineBlockCommentIgnoredWithExtraText() {
+        let javaSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.java")
+
+        // Extra text alongside the snippet marker - should be treated as regular content
+        let source = """
+        // A Java example
+
+        /*
+          snippet.hide
+          some extra text
+        */
+        import java.util.List;
+        List<String> items = List.of("a", "b");
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: javaSourceFile)
+        XCTAssertEqual("A Java example", snippet.explanation)
+        // All lines should appear since the block comment is not a snippet marker
+        XCTAssertTrue(snippet.presentationCode.contains("/*"))
+        XCTAssertTrue(snippet.presentationCode.contains("snippet.hide"))
+        XCTAssertTrue(snippet.presentationCode.contains("import java.util.List;"))
+    }
+
+    func testParseMultilineBlockCommentIgnoredWithExtraTextAfterMarker() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!--
+          snippet.hide another
+        -->
+        <!DOCTYPE html>
+        <p>Hello</p>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        // The multiline block comment is not a valid snippet marker, so all content appears
+        XCTAssertTrue(snippet.presentationCode.contains("<!--"))
+        XCTAssertTrue(snippet.presentationCode.contains("snippet.hide another"))
+        XCTAssertTrue(snippet.presentationCode.contains("<!DOCTYPE html>"))
+    }
+
+    func testParseMultilineBlockCommentSlice() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        let source = """
+        <!-- An HTML example -->
+
+        <!--
+          snippet.body
+        -->
+        <div>
+            <!--
+                 Normal multi line comment
+            -->
+            Content
+            <!-- Normal single line comment -->
+        </div>
+        <!--
+          snippet.end
+        -->
+
+        <footer>End</footer>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(snippet["body"],
+            """
+            <div>
+                <!--
+                     Normal multi line comment
+                -->
+                Content
+                <!-- Normal single line comment -->
+            </div>
+            """)
+    }
+
+    func testParseMultilineBlockCommentUnclosed() {
+        let htmlSourceFile = Self.fakeSnippetsDir
+            .appendingPathComponent("Example.html")
+
+        // An unclosed block comment should just be treated as presentation content
+        let source = """
+        <!-- An HTML example -->
+
+        <!--
+          snippet.hide
+        <p>Hello</p>
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
+        XCTAssertEqual("An HTML example", snippet.explanation)
+        // All lines after the explanation should be presentation content
+        XCTAssertTrue(snippet.presentationCode.contains("<!--"))
+        XCTAssertTrue(snippet.presentationCode.contains("snippet.hide"))
+        XCTAssertTrue(snippet.presentationCode.contains("<p>Hello</p>"))
+    }
+}

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -479,7 +479,7 @@ class SnippetParseTests: XCTestCase {
         let source = """
         // A Java example showing basic usage.
 
-        // snippet.hide
+        /* snippet.hide */
         import java.util.List;
         // snippet.show
 

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -1035,12 +1035,20 @@ class SnippetParseMultilineBlockCommentTests: XCTestCase {
           snippet.end
         -->
 
+        <!--
+             snippet.something
+         -->
+        <p>Some other content here</p>
+        <!--
+             snippet.end
+        -->
+
         <footer>End</footer>
         """
 
         let snippet = Snippet(parsing: source, sourceFile: htmlSourceFile)
         XCTAssertEqual("An HTML example", snippet.explanation)
-        XCTAssertEqual(1, snippet.slices.count)
+        XCTAssertEqual(2, snippet.slices.count)
         XCTAssertEqual(snippet["body"],
             """
             <div>
@@ -1051,6 +1059,7 @@ class SnippetParseMultilineBlockCommentTests: XCTestCase {
                 <!-- Normal single line comment -->
             </div>
             """)
+        XCTAssertEqual(snippet["something"], "<p>Some other content here</p>")
     }
 
     func testParseMultilineBlockCommentUnclosed() {

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -508,6 +508,9 @@ class SnippetParseTests: XCTestCase {
     }
 
     func testParseCppSnippet() {
+        let cppSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.cpp")
+
         let source = """
         // A C++ snippet
 
@@ -521,7 +524,7 @@ class SnippetParseTests: XCTestCase {
         }
         """
 
-        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        let snippet = Snippet(parsing: source, sourceFile: cppSourceFile)
         XCTAssertEqual("A C++ snippet", snippet.explanation)
         XCTAssertEqual("""
         int main() {

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetExtractTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetExtractTests.swift
@@ -255,6 +255,56 @@ final class SnippetExtractTests: XCTestCase {
         XCTAssertNil(snippetDirectory)
     }
 
+    func testSnippetGenerationWithMixedFileExtensions() throws {
+        let expectedFilePaths: Set<String> = [
+            "/my/package/Snippets",
+            "/test-working-directory/.build/symbol-graphs/snippet-symbol-graphs/MyPackage-package-id/MyPackage-snippets.symbols.json",
+        ]
+        let existingFilePaths: Set<String> = [
+            "/my/package/Snippets",
+            "/test-working-directory/.build/symbol-graphs/snippet-symbol-graphs/MyPackage-package-id/MyPackage-snippets.symbols.json",
+        ]
+        snippetExtractor._fileExists = { path in
+            XCTAssertTrue(
+                expectedFilePaths.contains(path),
+                "Unexpected file path: '\(path)'"
+            )
+            return existingFilePaths.contains(path)
+        }
+
+        snippetExtractor._findSnippetFilesInDirectory = { _ in
+            [
+                "/my/package/Snippets/SwiftExample.swift",
+                "/my/package/Snippets/JavaExample.java",
+                "/my/package/Snippets/CppExample.cpp",
+            ]
+        }
+
+        var capturedArguments: [String]?
+        snippetExtractor._runProcess = { process in
+            capturedArguments = process.arguments
+        }
+
+        let snippetFile = try snippetExtractor.generateSnippets(
+            for: "package-id",
+            packageDisplayName: "MyPackage",
+            packageDirectory: URL(fileURLWithPath: "/my/package")
+        )
+
+        XCTAssertNotNil(snippetFile)
+        // Verify all three files were passed to the snippet-extract tool
+        XCTAssertEqual(
+            capturedArguments,
+            [
+                "--output", "/test-working-directory/.build/symbol-graphs/snippet-symbol-graphs/MyPackage-package-id/MyPackage-snippets.symbols.json",
+                "--module-name", "MyPackage",
+                "/my/package/Snippets/SwiftExample.swift",
+                "/my/package/Snippets/JavaExample.java",
+                "/my/package/Snippets/CppExample.cpp",
+            ]
+        )
+    }
+
     func testSnippetExtractArguments() throws {
         // Valid
         XCTAssertNoThrow(try SnippetExtractCommand(arguments: [

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetExtractTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetExtractTests.swift
@@ -305,6 +305,30 @@ final class SnippetExtractTests: XCTestCase {
         )
     }
 
+    func testFindSnippetFilesSkipsFilesWithoutExtension() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SnippetExtractTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filesWithExtension = ["Example.swift", "Hello.java", "Config.yaml", "Script.py", "Unknown.pkl"]
+        let filesWithoutExtension = ["Makefile", "Dockerfile", "README"]
+        for name in filesWithExtension + filesWithoutExtension {
+            FileManager.default.createFile(atPath: tempDir.appendingPathComponent(name).path, contents: nil)
+        }
+
+        let foundFiles = snippetExtractor._findSnippetFilesInDirectory(tempDir)
+        let foundNames = Set(foundFiles.map { URL(fileURLWithPath: $0).lastPathComponent })
+
+        for name in filesWithExtension {
+            XCTAssertTrue(foundNames.contains(name), "Expected to find \(name)")
+        }
+
+        for name in filesWithoutExtension {
+            XCTAssertFalse(foundNames.contains(name), "Expected to skip \(name)")
+        }
+    }
+
     func testSnippetExtractArguments() throws {
         // Valid
         XCTAssertNoThrow(try SnippetExtractCommand(arguments: [

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
@@ -58,4 +58,18 @@ class SnippetSymbolTests: XCTestCase {
         let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
         XCTAssertEqual("java", snippetMixin?.language)
     }
+
+    func testPathComponentsForPythonSnippetSymbol() throws {
+        let source = """
+        # A Python snippet
+        print("hello")
+        """
+        let snippet = Snippets.Snippet(parsing: source,
+                                       sourceFile: URL(fileURLWithPath: "/path/to/my-package/Snippets/Hello.py"))
+        let symbol = try SymbolGraph.Symbol(snippet, moduleName: "my-package")
+        XCTAssertEqual(["Snippets", "Hello"], symbol.pathComponents)
+        XCTAssertEqual("python", symbol.identifier.interfaceLanguage)
+        let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
+        XCTAssertEqual("python", snippetMixin?.language)
+    }
 }

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
@@ -72,4 +72,19 @@ class SnippetSymbolTests: XCTestCase {
         let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
         XCTAssertEqual("python", snippetMixin?.language)
     }
+
+    func testPathComponentsForUnknownLanguageSnippetSymbol() throws {
+        let source = """
+        // A Pkl snippet
+        host = "localhost"
+        """
+        let snippet = Snippets.Snippet(parsing: source,
+                                       sourceFile: URL(fileURLWithPath: "/path/to/my-package/Snippets/Config.pkl"))
+        let symbol = try SymbolGraph.Symbol(snippet, moduleName: "my-package")
+        XCTAssertEqual(["Snippets", "Config"], symbol.pathComponents)
+        // Unknown languages fall back to using the file extension as the language id
+        XCTAssertEqual("pkl", symbol.identifier.interfaceLanguage)
+        let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
+        XCTAssertEqual("pkl", snippetMixin?.language)
+    }
 }

--- a/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/Snippets/SnippetSymbolTests.swift
@@ -40,5 +40,22 @@ class SnippetSymbolTests: XCTestCase {
                                        sourceFile: URL(fileURLWithPath: "/path/to/my-package/Snippets/ASnippet.swift"))
         let symbol = try SymbolGraph.Symbol(snippet, moduleName: "my-package")
         XCTAssertEqual(["Snippets", "ASnippet"], symbol.pathComponents)
+        XCTAssertEqual("swift", symbol.identifier.interfaceLanguage)
+        let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
+        XCTAssertEqual("swift", snippetMixin?.language)
+    }
+
+    func testPathComponentsForJavaSnippetSymbol() throws {
+        let source = """
+        // A Java snippet.
+        public class Hello {}
+        """
+        let snippet = Snippets.Snippet(parsing: source,
+                                       sourceFile: URL(fileURLWithPath: "/path/to/my-package/Snippets/Hello.java"))
+        let symbol = try SymbolGraph.Symbol(snippet, moduleName: "my-package")
+        XCTAssertEqual(["Snippets", "Hello"], symbol.pathComponents)
+        XCTAssertEqual("java", symbol.identifier.interfaceLanguage)
+        let snippetMixin = symbol[mixin: SymbolGraph.Symbol.Snippet.self]
+        XCTAssertEqual("java", snippetMixin?.language)
     }
 }

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
+    sed -e 's/20[12][6789012345]-20[12][6789012345]/YEARS/' -e 's/20[12][6789012345]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
This resolves https://github.com/swiftlang/swift-docc/issues/1436

## Summary

This removes the restriction of only scanning .swift files and we try to detect the language based on the extension. If a language is not known, we pass the extension instead as a fallback -- this should be acceptable for most cases.

This is important to unblock swift-java documenting its feature set with compiling examples, like this:
<img width="1961" height="715" alt="Screenshot 2026-04-03 at 12 56 34" src="https://github.com/user-attachments/assets/e436af51-9611-49f5-a736-cc69ce902ba4" />




## Testing

Added tests

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary
