### PR TITLE
Workaround issue generating symbol graphs for executables

### DIFF
--- a/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
@@ -46,6 +46,7 @@ extension XCTestCase {
         
         process.arguments = [
             "package",
+            "--build-system", "native", // FIXME: Remove this workaround once rdar://175674487 is fixed
             "--cache-path", swiftPMCacheDirectory.path,
             "--build-path", swiftPMBuildDirectory.path,
         ] + arguments.map(\.description)


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This adds a workaround in the tests to unblock the CI. 
We should remove this workaround once rdar://175674487 is fixed.

## Dependencies

None

## Testing

This workaround works if the tests pass in CI. 

You can locally reproduce the issue by running the integration tests using the `swift-DEVELOPMENT-SNAPSHOT-2026-04-01-a.xctoolchain` toolchain (same as the CI).

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~Added tests~
- [x] Ran the `./bin/test` script and it succeeded
- [ ] ~Updated documentation if necessary~
