### PR TITLE
Revert "Workaround issue generating symbol graphs for executables"

### DIFF
--- a/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
+++ b/IntegrationTests/Tests/Utility/XCTestCase+swiftPackage.swift
@@ -46,7 +46,6 @@ extension XCTestCase {
         
         process.arguments = [
             "package",
-            "--build-system", "native", // FIXME: Remove this workaround once rdar://175674487 is fixed
             "--cache-path", swiftPMCacheDirectory.path,
             "--build-path", swiftPMBuildDirectory.path,
         ] + arguments.map(\.description)


### PR DESCRIPTION
Reverts swiftlang/swift-docc-plugin#122

We'll keep this PR as a draft to reming us to remove this workaround.