### PR TITLE
Ignore snippet markers inside multiline string literals

### DIFF
--- a/Sources/Snippets/Model/Snippet.swift
+++ b/Sources/Snippets/Model/Snippet.swift
@@ -34,7 +34,13 @@ public struct Snippet {
 
     init(parsing source: String, sourceFile: URL) {
         let commentStyles = SnippetLanguage.commentStyles(forFileExtension: sourceFile.pathExtension)
-        let extractor = SnippetParser(source: source, commentStyles: commentStyles, sourceFile: sourceFile.lastPathComponent)
+        let stringLiteralSyntax = SnippetLanguage.stringLiteralSyntax(forFileExtension: sourceFile.pathExtension)
+        let extractor = SnippetParser(
+            source: source,
+            commentStyles: commentStyles,
+            stringLiteralSyntax: stringLiteralSyntax,
+            sourceFile: sourceFile.lastPathComponent
+        )
         self.explanation = extractor.explanationLines.joined(separator: "\n")
         self.presentationLines = extractor.presentationLines.map(String.init)
         self.slices = extractor.slices

--- a/Sources/Snippets/Model/SnippetLanguage.swift
+++ b/Sources/Snippets/Model/SnippetLanguage.swift
@@ -39,6 +39,35 @@ public enum CommentStyle: Sendable {
     }
 }
 
+/// The multiline string literal syntax used by a language.
+///
+/// Snippet markers are line comments such as `// snippet.show`. When such a
+/// sequence appears inside a multiline string literal it is literal text, not a
+/// marker, so the parser must know how a language opens and closes these
+/// literals in order to ignore markers found within them.
+public struct StringLiteralSyntax: Sendable {
+    /// The delimiter that opens and closes a multiline string literal, e.g. `"""`.
+    public var multilineDelimiter: String
+
+    /// Whether the language allows raw-string customization of the delimiter by
+    /// surrounding it with one or more `#` characters, e.g. Swift's `#"""..."""#`.
+    ///
+    /// When `true`, an opening delimiter may be preceded by a run of `#`
+    /// characters and is only closed by the delimiter followed by the same
+    /// number of `#` characters.
+    public var allowsRawDelimiter: Bool
+
+    public init(multilineDelimiter: String, allowsRawDelimiter: Bool) {
+        self.multilineDelimiter = multilineDelimiter
+        self.allowsRawDelimiter = allowsRawDelimiter
+    }
+
+    /// Swift's multiline string literal syntax: `"""`, optionally raw (`#"""..."""#`).
+    public static var swift: Self {
+        .init(multilineDelimiter: "\"\"\"", allowsRawDelimiter: true)
+    }
+}
+
 /// A programming language supported for code snippets
 public enum SnippetLanguage: String, CaseIterable, Sendable {
     case swift
@@ -77,6 +106,19 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
             return [.xml]
         default:
             return [.slashSlash, .cBlock]
+        }
+    }
+
+    /// The multiline string literal syntax used by this language, if any.
+    ///
+    /// Languages without a known multiline string literal syntax return `nil`,
+    /// in which case the parser does not track string literal state for them.
+    public var stringLiteralSyntax: StringLiteralSyntax? {
+        switch self {
+        case .swift:
+            return .swift
+        default:
+            return nil
         }
     }
 
@@ -132,5 +174,14 @@ public enum SnippetLanguage: String, CaseIterable, Sendable {
             // wild guess, let's assume those are fine
             [.slashSlash, .hash]
         }
+    }
+
+    /// Look up the multiline string literal syntax for a given file extension.
+    ///
+    /// - Parameter ext: A file extension (without the leading dot), e.g. `"swift"`.
+    /// - Returns: The matching syntax, or `nil` if the extension is unknown or the
+    ///   language has no tracked multiline string literal syntax.
+    public static func stringLiteralSyntax(forFileExtension ext: String) -> StringLiteralSyntax? {
+        language(forFileExtension: ext)?.stringLiteralSyntax
     }
 }

--- a/Sources/Snippets/Parsing/SnippetParser.swift
+++ b/Sources/Snippets/Parsing/SnippetParser.swift
@@ -73,6 +73,7 @@ extension Substring {
 struct SnippetParser {
     var source: String
     var commentStyles: [CommentStyle]
+    var stringLiteralSyntax: StringLiteralSyntax?
     var explanationLines = [Substring]()
     var presentationLines = [Substring]()
     var slices = [String: Range<Int>]()
@@ -202,9 +203,10 @@ struct SnippetParser {
         }
     }
 
-    init(source: String, commentStyles: [CommentStyle], sourceFile: String) {
+    init(source: String, commentStyles: [CommentStyle], stringLiteralSyntax: StringLiteralSyntax? = nil, sourceFile: String) {
         self.source = source
         self.commentStyles = commentStyles
+        self.stringLiteralSyntax = stringLiteralSyntax
         var lines = source.split(separator: "\n", omittingEmptySubsequences: false)[...]
             .drop { $0.isEmptyOrWhiteSpace }
 
@@ -212,10 +214,21 @@ struct SnippetParser {
 
         var lineNumber = 0
         var pendingBlockComment: PendingBlockComment? = nil
+        var stringScanner = stringLiteralSyntax.map(MultilineStringScanner.init)
 
         for index in lines.indices {
             let line = lines[index]
             let sourceLineNumber = index + 1 // 1-based
+
+            // A line whose start lies inside an open multiline string literal is
+            // literal text, never a snippet marker or comment. Emit it as
+            // presentation content and let the scanner consume it to track when
+            // the literal closes.
+            if stringScanner?.isInsideMultilineString == true {
+                appendPresentationLines([line], lineNumber: &lineNumber)
+                stringScanner?.consume(line: line)
+                continue
+            }
 
             // If we're accumulating a multiline block comment, feed this line in.
             if var pending = pendingBlockComment {
@@ -248,11 +261,20 @@ struct SnippetParser {
                     from: line, at: index, commentStyles: commentStyles
                 ) {
                     pendingBlockComment = pending
-                } else if isVisible &&
-                    // Don't include leading empty lines in the presentation content
-                    !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace) {
-                    presentationLines.append(line)
-                    lineNumber += 1
+                } else {
+                    // Only ordinary code lines can open a multiline string literal;
+                    // snippet markers and block comments never can. Let the scanner
+                    // observe this line, regardless of visibility, so a literal opened
+                    // here (e.g. `let x = """`) is tracked on later lines and their
+                    // marker-like contents are not misread as markers.
+                    stringScanner?.consume(line: line)
+
+                    if isVisible &&
+                        // Don't include leading empty lines in the presentation content
+                        !(presentationLines.isEmpty && line.isEmptyOrWhiteSpace) {
+                        presentationLines.append(line)
+                        lineNumber += 1
+                    }
                 }
             }
 
@@ -504,6 +526,164 @@ extension SnippetParser {
             }
         }
         return nil
+    }
+}
+
+// MARK: Multiline string literal tracking
+
+/// Tracks whether the current line lies inside an open multiline string literal.
+///
+/// Snippet markers are line comments such as `// snippet.show`. The same text can
+/// appear verbatim inside a multiline string literal, where it is content rather
+/// than a marker. This scanner is fed each source line in order and reports
+/// whether the start of the next line is inside an open literal so the parser can
+/// avoid treating its contents as markers.
+///
+/// The scanner understands single-line string literals and line comments well
+/// enough to avoid being misled by a delimiter that appears inside them. It does
+/// not attempt to track delimiters that appear inside block comments, which is not
+/// a realistic scenario for snippet markers.
+struct MultilineStringScanner {
+    private let syntax: StringLiteralSyntax
+    private let delimiter: [Character]
+
+    /// When inside a multiline literal, the number of `#` characters required to
+    /// close it. `nil` means we are not currently inside a multiline literal.
+    private var openRawHashCount: Int?
+
+    init(syntax: StringLiteralSyntax) {
+        self.syntax = syntax
+        self.delimiter = Array(syntax.multilineDelimiter)
+    }
+
+    /// Whether the start of the next line lies inside an open multiline string literal.
+    var isInsideMultilineString: Bool {
+        openRawHashCount != nil
+    }
+
+    /// Update the scanner's state with the next source line.
+    mutating func consume(line: Substring) {
+        let characters = Array(line)
+        var index = 0
+
+        while index < characters.count {
+            if let requiredHashes = openRawHashCount {
+                // Inside a multiline literal: look only for the matching close.
+                if matchesDelimiter(in: characters, at: index, trailingHashes: requiredHashes) {
+                    index += delimiter.count + requiredHashes
+                    openRawHashCount = nil
+                } else {
+                    index += 1
+                }
+                continue
+            }
+
+            let character = characters[index]
+
+            // A line comment hides everything to the end of the line.
+            if character == "/", index + 1 < characters.count, characters[index + 1] == "/" {
+                return
+            }
+
+            // A run of `#` may introduce a raw string literal.
+            if character == "#" {
+                let hashCount = countHashes(in: characters, from: index)
+                let afterHashes = index + hashCount
+                if afterHashes < characters.count, characters[afterHashes] == "\"" {
+                    index = consumeStringLiteral(in: characters, quoteIndex: afterHashes, leadingHashes: hashCount)
+                } else {
+                    index = afterHashes
+                }
+                continue
+            }
+
+            if character == "\"" {
+                index = consumeStringLiteral(in: characters, quoteIndex: index, leadingHashes: 0)
+                continue
+            }
+
+            index += 1
+        }
+    }
+
+    /// Consume a string literal that begins at `quoteIndex` (the first `"`), with
+    /// `leadingHashes` raw-string `#` characters already before it.
+    ///
+    /// Returns the index just past the literal. If the literal is an unterminated
+    /// multiline literal, records the open state and returns the end of the line.
+    private mutating func consumeStringLiteral(
+        in characters: [Character],
+        quoteIndex: Int,
+        leadingHashes: Int
+    ) -> Int {
+        let isMultiline = matchesDelimiter(in: characters, at: quoteIndex, trailingHashes: 0)
+        if isMultiline {
+            var index = quoteIndex + delimiter.count
+            // A multiline literal may open and close on the same line.
+            while index < characters.count {
+                if matchesDelimiter(in: characters, at: index, trailingHashes: leadingHashes) {
+                    return index + delimiter.count + leadingHashes
+                }
+                index += 1
+            }
+            // Unterminated on this line: the literal stays open on later lines.
+            openRawHashCount = leadingHashes
+            return characters.count
+        }
+
+        // Single-line string literal: always closes before the end of the line.
+        let allowsEscapes = leadingHashes == 0
+        var index = quoteIndex + 1
+        while index < characters.count {
+            let character = characters[index]
+            if allowsEscapes, character == "\\" {
+                index += 2
+                continue
+            }
+            if character == "\"", trailingHashesMatch(in: characters, at: index + 1, count: leadingHashes) {
+                return index + 1 + leadingHashes
+            }
+            index += 1
+        }
+        return characters.count
+    }
+
+    /// Count the run of `#` characters starting at `start`.
+    private func countHashes(in characters: [Character], from start: Int) -> Int {
+        var index = start
+        while index < characters.count, characters[index] == "#" {
+            index += 1
+        }
+        return index - start
+    }
+
+    /// Whether `delimiter` followed by `trailingHashes` `#` characters appears at `index`.
+    private func matchesDelimiter(in characters: [Character], at index: Int, trailingHashes: Int) -> Bool {
+        guard index + delimiter.count + trailingHashes <= characters.count else {
+            return false
+        }
+        for offset in 0..<delimiter.count where characters[index + offset] != delimiter[offset] {
+            return false
+        }
+        return trailingHashesMatch(in: characters, at: index + delimiter.count, count: trailingHashes)
+    }
+
+    /// Whether exactly `count` `#` characters appear at `index` (and not one more).
+    private func trailingHashesMatch(in characters: [Character], at index: Int, count: Int) -> Bool {
+        guard syntax.allowsRawDelimiter || count == 0 else {
+            return false
+        }
+        guard index + count <= characters.count else {
+            return false
+        }
+        for offset in 0..<count where characters[index + offset] != "#" {
+            return false
+        }
+        // For a raw literal, a longer run of `#` than required does not close it.
+        if count > 0, index + count < characters.count, characters[index + count] == "#" {
+            return false
+        }
+        return true
     }
 }
 

--- a/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift
@@ -744,6 +744,145 @@ class SnippetParseTests: XCTestCase {
         """
         XCTAssertEqual(expectedCode, snippet.presentationCode)
     }
+
+    // MARK: String literal tests
+
+    /// Comment-like lines inside a Swift multiline string literal are content,
+    /// not snippet markers, so the whole literal is shown intact.
+    func testMultilineStringLiteralIgnoresMarkers() {
+        let source = """
+        // snippet.hide
+        import Snippets_Example
+
+        // snippet.show
+        let text = \"\"\"
+        Only this part of the code will be shown.
+
+        // snippet.hide
+
+        Snippet markers inside multiline string literals are ignored.
+
+        // snippet.show
+        \"\"\"
+        """
+
+        let expectedCode = """
+        let text = \"\"\"
+        Only this part of the code will be shown.
+
+        // snippet.hide
+
+        Snippet markers inside multiline string literals are ignored.
+
+        // snippet.show
+        \"\"\"
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    /// Markers continue to work normally on lines after a multiline string literal closes.
+    func testMarkersResumeAfterMultilineStringLiteral() {
+        let source = """
+        let text = \"\"\"
+        // snippet.hide
+        \"\"\"
+        // snippet.hide
+        hidden()
+        // snippet.show
+        shown()
+        """
+
+        let expectedCode = """
+        let text = \"\"\"
+        // snippet.hide
+        \"\"\"
+        shown()
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    /// Markers inside a raw multiline string literal (`#"""..."""#`) are ignored,
+    /// and only the matching number of `#` characters closes it.
+    func testRawMultilineStringLiteralIgnoresMarkers() {
+        let source = """
+        let text = #\"\"\"
+        // snippet.hide
+        \"\"\" still inside because the closing needs a trailing #
+        // snippet.show
+        \"\"\"#
+        after()
+        """
+
+        let expectedCode = """
+        let text = #\"\"\"
+        // snippet.hide
+        \"\"\" still inside because the closing needs a trailing #
+        // snippet.show
+        \"\"\"#
+        after()
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual(expectedCode, snippet.presentationCode)
+    }
+
+    /// A single-line string literal that contains marker-like text on a code line
+    /// is left untouched and does not open multiline tracking.
+    func testSingleLineStringLiteralWithMarkerLikeText() {
+        let source = """
+        let a = "// snippet.hide"
+        let b = 2
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual(source, snippet.presentationCode)
+    }
+
+    /// String literal tracking is language-specific. A `#`-comment language such
+    /// as a shell script does not treat `"""` as a string literal delimiter.
+    func testNonSwiftLanguageDoesNotTrackSwiftStringLiterals() {
+        let shellSourceFile = SnippetParseTests.fakeSnippetsDir
+            .appendingPathComponent("Example.sh")
+        let source = """
+        echo \"\"\"
+        # snippet.hide
+        hidden
+        # snippet.show
+        shown
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: shellSourceFile)
+        // The shell parser has no `"""` literal, so the `# snippet.*` markers apply.
+        XCTAssertEqual("echo \"\"\"\nshown", snippet.presentationCode)
+    }
+
+    /// A slice that contains a multiline string literal keeps a correct line range,
+    /// and marker-like lines inside the literal are part of the slice content.
+    func testSliceContainingMultilineStringLiteral() {
+        let source = """
+        // snippet.foo
+        let text = \"\"\"
+        // snippet.end
+        \"\"\"
+        use(text)
+        // snippet.end
+        after()
+        """
+
+        let expectedSlice = """
+        let text = \"\"\"
+        // snippet.end
+        \"\"\"
+        use(text)
+        """
+
+        let snippet = Snippet(parsing: source, sourceFile: SnippetParseTests.fakeSourceFilename)
+        XCTAssertEqual(expectedSlice, snippet["foo"])
+    }
 }
 
 class SnippetParseWarningTests: XCTestCase {


### PR DESCRIPTION
Bug/issue #: swiftlang/swift-docc#946

## Summary

Snippet slice markers are line comments of the form `// snippet.show`, `// snippet.hide`, `// snippet.<name>`, and `// snippet.end`. The parser matched them line by line with no awareness of string literals, so a line like `// snippet.hide` that appears inside a Swift multiline string literal was treated as a real marker. That cut the literal at the marker line and dropped the surrounding text, and in some arrangements it left unbalanced `"""` delimiters in the presented code.

For example, this snippet:

```swift
// snippet.show
let text = """
Only this part of the code will be shown.

// snippet.hide

Snippet markers inside multiline string literals are ignored.

// snippet.show
"""
```

previously rendered with the literal sliced at the inner `// snippet.hide` / `// snippet.show` lines instead of showing the whole string.

This adds a small per-language string literal scanner. It is fed each source line in order and reports whether the start of the next line lies inside an open multiline string literal, including raw literals such as `#"""..."""#` where the closing delimiter must carry the matching number of `#` characters. While the parser is inside such a literal it emits the line as presentation content and never interprets it as a marker or comment.

The string literal syntax is language specific (`StringLiteralSyntax`) and is currently enabled for Swift only, looked up by file extension alongside the existing comment style lookup. Languages without a known multiline string syntax are unaffected, so the `#`, XML, and other comment styles behave exactly as before.

The scanner intentionally does not track delimiters that appear inside block comments, which is not a realistic case for snippet markers and is noted in the code.

## Dependencies

None. The fix and tests are contained in this repository.

## Testing

Steps:
1. `swift test --filter SnippetParse`

New tests in `Tests/SwiftDocCPluginUtilitiesTests/SnippetParseTests.swift` cover:
- markers inside a plain multiline string literal are ignored and the literal is shown intact
- markers resume working on lines after a multiline literal closes
- raw multiline literals (`#"""..."""#`), where a bare `"""` does not close the literal
- a single-line string containing marker-like text on a code line is left untouched
- a non-Swift language (shell, `#` comments) does not treat `"""` as a literal delimiter
- a slice whose body contains a multiline literal keeps a correct line range

The full `SwiftDocCPluginUtilitiesTests` suite passes (83 tests). I ran `swift test` with `SWIFT_SKIP_BUILDING_UPSTREAM_DOCC=true`; I did not run the full `./bin/test` integration path that builds upstream swift-docc, since this change is exercised entirely by the unit tests.

## Checklist

- [x] Added tests
- [ ] Ran the `./bin/test` script and it succeeded (ran `swift test` for the affected target; did not run the upstream-DocC integration path)
- [x] Updated documentation if necessary (no user-facing docs change; the behavior now matches the documented marker semantics)
