### PR TITLE
Add --json-prettyprint plugin option

### DIFF
--- a/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
+++ b/Plugins/Swift-DocC Convert/SwiftDocCConvert.swift
@@ -137,7 +137,11 @@ import PackagePlugin
             let conversionStartTime = DispatchTime.now()
             
             // Run `docc convert` with the generated arguments and wait until the process completes
-            let process = try Process.run(doccExecutableURL, arguments: doccArguments)
+            let process = Process()
+            process.executableURL = doccExecutableURL
+            process.arguments = doccArguments
+            process.environment = parsedArguments.doccEnvironment
+            try process.run()
             process.waitUntilExit()
             
             // Check whether the `docc convert` invocation was successful.
@@ -228,7 +232,11 @@ import PackagePlugin
         }
         
         // Create a new combined archive
-        let process = try Process.run(doccExecutableURL, arguments: mergeCommandArguments.remainingArguments)
+        let process = Process()
+        process.executableURL = doccExecutableURL
+        process.arguments = mergeCommandArguments.remainingArguments
+        process.environment = parsedArguments.doccEnvironment
+        try process.run()
         process.waitUntilExit()
         
         print("""

--- a/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
+++ b/Plugins/Swift-DocC Preview/SwiftDocCPreview.swift
@@ -125,6 +125,7 @@ import PackagePlugin
         let previewProcess = Process()
         previewProcess.executableURL = doccExecutableURL
         previewProcess.arguments = doccArguments
+        previewProcess.environment = parsedArguments.doccEnvironment
         
         
         func stopPreviewProcess() {

--- a/Sources/SwiftDocCPluginUtilities/CommandLineArguments/ParsedPluginArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/CommandLineArguments/ParsedPluginArguments.swift
@@ -12,6 +12,7 @@ import Foundation
 struct ParsedPluginArguments {
     var enableCombinedDocumentation: Bool
     var disableLMDBIndex: Bool
+    var jsonPrettyPrint: Bool
     var verbose: Bool
     var help: Bool
     
@@ -19,6 +20,7 @@ struct ParsedPluginArguments {
     init(extractingFrom arguments: inout CommandLineArguments) {
         enableCombinedDocumentation = arguments.extractFlag(.enableCombinedDocumentation) ?? false
         disableLMDBIndex = arguments.extractFlag(.disableLMDBIndex) ?? false
+        jsonPrettyPrint   = arguments.extractFlag(.jsonPrettyPrint)   ?? false
         verbose          = arguments.extractFlag(.verbose)          ?? false
         help             = arguments.extract(Self.help).last        ?? false
     }

--- a/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
+++ b/Sources/SwiftDocCPluginUtilities/DocumentedPluginFlags/DocumentedArgument.swift
@@ -71,6 +71,16 @@ extension DocumentedArgument {
             Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
             """
     )
+
+    /// A plugin feature flag to enable pretty-printing of JSON output.
+    static let jsonPrettyPrint = Self(
+        flag: .init(preferred: "--json-prettyprint"),
+        abstract: "Pretty-print and order JSON output.",
+        discussion: """
+            Produces JSON output with stable formatting, which is useful when committing generated
+            documentation to a repository.
+            """
+    )
     
     /// A plugin feature flag to enable verbose logging.
     static let verbose = Self(

--- a/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
+++ b/Sources/SwiftDocCPluginUtilities/HelpInformation.swift
@@ -45,6 +45,7 @@ public enum HelpInformation {
         
         var supportedPluginFlags = [
             DocumentedArgument.disableLMDBIndex,
+            DocumentedArgument.jsonPrettyPrint,
             DocumentedArgument.verbose,
         ]
         
@@ -192,4 +193,3 @@ private extension Process {
         }
     }
 }
-

--- a/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
+++ b/Sources/SwiftDocCPluginUtilities/ParsedArguments.swift
@@ -36,6 +36,15 @@ struct ParsedArguments {
     
     /// The location where the plugin should write the output documentation archive(s).
     var outputDirectory: URL?
+
+    /// Returns the environment to use when invoking DocC.
+    var doccEnvironment: [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        if pluginArguments.jsonPrettyPrint {
+            environment["DOCC_JSON_PRETTYPRINT"] = "YES"
+        }
+        return environment
+    }
     
     /// Returns the arguments that should be passed to `docc` to invoke the given plugin action.
     ///

--- a/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/HelpInformationTests.swift
@@ -40,6 +40,9 @@ final class HelpInformationTests: XCTestCase {
               --disable-indexing, --no-indexing
                                       Disable indexing for the produced DocC archive.
                     Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
+              --json-prettyprint       Pretty-print and order JSON output.
+                    Produces JSON output with stable formatting, which is useful when committing generated
+                    documentation to a repository.
               --verbose               Increase verbosity to include informational output.
             
             SYMBOL GRAPH OPTIONS:
@@ -187,6 +190,9 @@ final class HelpInformationTests: XCTestCase {
               --disable-indexing, --no-indexing
                                       Disable indexing for the produced DocC archive.
                     Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
+              --json-prettyprint       Pretty-print and order JSON output.
+                    Produces JSON output with stable formatting, which is useful when committing generated
+                    documentation to a repository.
               --verbose               Increase verbosity to include informational output.
             
             SYMBOL GRAPH OPTIONS:

--- a/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
+++ b/Tests/SwiftDocCPluginUtilitiesTests/ParsedArgumentsTests.swift
@@ -28,6 +28,21 @@ final class ParsedArgumentsTests: XCTestCase {
         
         XCTAssertFalse(ParsedArguments(["--hel"]).pluginArguments.help)
     }
+
+    func testJSONPrettyPrint() {
+        let arguments = ParsedArguments(["--json-prettyprint"])
+
+        XCTAssertTrue(arguments.pluginArguments.jsonPrettyPrint)
+        XCTAssertEqual(arguments.doccEnvironment["DOCC_JSON_PRETTYPRINT"], "YES")
+        XCTAssertFalse(arguments.doccArguments(
+            action: .convert,
+            targetKind: .library,
+            doccCatalogPath: nil,
+            targetName: "MyTarget",
+            symbolGraphDirectoryPath: "/my/symbol-graph",
+            outputPath: "/my/output-path"
+        ).contains("--json-prettyprint"))
+    }
     
     func testDocCArgumentsForNoArguments() {
         let arguments = ParsedArguments([])


### PR DESCRIPTION
## Summary

- Add a `--json-prettyprint` plugin option for deterministic, readable DocC JSON output.
- Set `DOCC_JSON_PRETTYPRINT=YES` for convert, preview, and combined archive invocations.
- Add parsing, environment propagation, and help text coverage.

Resolves #127.

## Test plan

- `swift build`
- `LC_ALL=C ./bin/check-source`
- `swift test --filter SwiftDocCPluginUtilitiesTests` *(blocked locally because the installed CommandLineTools does not include XCTest; CI should provide the test result)*
